### PR TITLE
external-secrets-add-k8s-clustersecretstore: adding cluster_secret_store

### DIFF
--- a/input/config.yaml
+++ b/input/config.yaml
@@ -22,6 +22,9 @@
   name: external-secrets
   namespace: "external-secrets"
   helm-version: "0.10.3"
+- name: external-secrets-cluster-secret-store
+  namespace: external-secrets
+  sourcefile: external-secrets/k8s-provider-related.yaml
 - helm-chart-name: "psmdb-operator"
   helm-name: psmdb-operator
   helm-url: "https://percona.github.io/percona-helm-charts"

--- a/input/external-secrets/k8s-provider-related.yaml
+++ b/input/external-secrets/k8s-provider-related.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-readonly
+  namespace: external-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-readonly
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - external-secrets.io
+  resources:
+  - secretstores
+  - clustersecretstores
+  - externalsecrets
+  - clusterexternalsecrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-readonly-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-readonly
+subjects:
+- kind: ServiceAccount
+  name: external-secrets-readonly
+  namespace: external-secrets
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: k8s-secret-store
+spec:
+  provider:
+    kubernetes:
+      server:
+        url: https://kubernetes.default.svc
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: default
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: external-secrets-readonly
+          namespace: external-secrets
+      remoteNamespace: default
+


### PR DESCRIPTION
This PR adds "ClusterSecretStore" having k8s secret as a backend.

The nominal capability of k8s provider would be "ReadWrite". However, SA "external-secrets-readonly" attached to "ClusterSecretStore" has verbs such as "Get", "List", "Watch".

So only fetching the values of a secret in default namespace is possible.