### PR TITLE
Add openobserve, opentelemtry-operator, and openobserve-collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Ensure the following tools are installed:
 
 
 ---
-## Instruction of deplying monitoring tools
+## Instruction of deploying monitoring tools
 - [OpenObserve](input/openobserve/README.md)
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Ensure the following tools are installed:
 
 
 ---
-
+## Instruction of deploy monitoring tools
+- [OpenObserve](input/openobserve/README.md)
 
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Ensure the following tools are installed:
 
 
 ---
-## Instruction of deploy monitoring tools
+## Instruction of deplying monitoring tools
 - [OpenObserve](input/openobserve/README.md)
 
 

--- a/input/config.yaml
+++ b/input/config.yaml
@@ -135,3 +135,17 @@
 - name: kube-prometheus-stack
   namespace: "prometheus-system"
   sourcefile: kube-prometheus-stack/kube-prometheus-stack-manifests.yaml
+- name: opentelemetry-operator
+  namespace: opentelemetry-operator-system
+  manifest-url: https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
+- helm-chart-name: "openobserve-standalone"
+  helm-name: o2
+  helm-url: "https://charts.openobserve.ai"
+  values: openobserve-standalone-values.yaml
+  secrets: true
+  name: openobserve
+  namespace: "openobserve"
+  helm-version: "0.14.1"
+- name: openobserve-collector
+  namespace: "openobserve-collector"
+  sourcefile: openobserve-collector/manifests.yaml

--- a/input/config.yaml
+++ b/input/config.yaml
@@ -149,3 +149,6 @@
 - name: openobserve-collector
   namespace: "openobserve-collector"
   sourcefile: openobserve-collector/manifests.yaml
+- name: prometheus-crds
+  namespace: prometheus-system
+  manifest-url: https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.79.2/stripped-down-crds.yaml

--- a/input/openobserve-collector/manifests.yaml
+++ b/input/openobserve-collector/manifests.yaml
@@ -1,0 +1,773 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  name: openobserve-collector
+---
+# Source: openobserve-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: o2c-openobserve-collector
+  namespace: "openobserve-collector"
+  labels:
+    helm.sh/chart: openobserve-collector-0.3.21
+    app.kubernetes.io/name: openobserve-collector
+    app.kubernetes.io/instance: o2c
+    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: openobserve-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: o2c-openobserve-collector
+  labels:
+    app: openobserve-collector
+rules:
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/metrics
+  - nodes/proxy
+  - persistentvolumes
+  - persistentvolumeclaims
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  - podmonitors
+  - probes
+  - scrapeconfigs
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  - cronjobs
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+    - horizontalpodautoscalers
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]
+---
+# Source: openobserve-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: o2c-openobserve-collector
+  labels:
+    app: openobserve-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: o2c-openobserve-collector
+subjects:
+- kind: ServiceAccount
+  name: o2c-openobserve-collector
+  namespace: "openobserve-collector"
+---
+# Source: openobserve-collector/templates/instrumentation-dotnet.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: openobserve-dotnet
+  namespace: "openobserve-collector"
+spec:
+  exporter:
+    endpoint: http://o2c-openobserve-collector-gateway-collector.openobserve-collector.svc.cluster.local:4318
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  dotnet:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+---
+# Source: openobserve-collector/templates/instrumentation-go.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: openobserve-go
+  namespace: "openobserve-collector"
+spec:
+  go:
+    # image: ghcr.io/openobserve/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.7.0-alpha-5
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.19.0-alpha
+  exporter:
+    endpoint: http://o2c-openobserve-collector-gateway-collector.openobserve-collector.svc.cluster.local:4318
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+---
+# Source: openobserve-collector/templates/instrumentation-java.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: openobserve-java
+  namespace: "openobserve-collector"
+spec:
+  exporter:
+    endpoint: http://o2c-openobserve-collector-gateway-collector.openobserve-collector.svc.cluster.local:4318
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  java:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+---
+# Source: openobserve-collector/templates/instrumentation-nodejs.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: openobserve-nodejs
+  namespace: "openobserve-collector"
+spec:
+  exporter:
+    endpoint: http://o2c-openobserve-collector-gateway-collector.openobserve-collector.svc.cluster.local:4317
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+---
+# Source: openobserve-collector/templates/instrumentation-python.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: openobserve-python
+  namespace: "openobserve-collector"
+spec:
+  exporter:
+    endpoint: http://o2c-openobserve-collector-gateway-collector.openobserve-collector.svc.cluster.local:4318
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  python:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_LOGS_EXPORTER
+        value: otlp_proto_http
+      - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+        value: "false" # set to true to enable auto instrumentation for logs
+---
+# Source: openobserve-collector/templates/agent.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: o2c-openobserve-collector-agent
+  namespace: "openobserve-collector"
+  labels:
+    helm.sh/chart: openobserve-collector-0.3.21
+    app.kubernetes.io/name: openobserve-collector
+    app.kubernetes.io/instance: o2c
+    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  mode: daemonset # "daemonset", "deployment" (default), "statefulset"
+  serviceAccount: o2c-openobserve-collector
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0"
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  tolerations:
+        - effect: NoSchedule
+          key: exampleKey1
+          operator: Equal
+          value: "true"
+  volumes:
+    - name: hostfs
+      hostPath:
+        path: /
+    - name: varlog
+      hostPath:
+        path: /var/log
+        type: ''
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+        type: ''
+  volumeMounts:
+    - name: hostfs
+      mountPath: /hostfs
+    - name: varlog
+      mountPath: /var/log
+    - name: varlibdockercontainers
+      readOnly: true
+      mountPath: /var/lib/docker/containers
+  resources: 
+    {}
+  securityContext: ##
+    runAsUser: 0 ##
+    runAsGroup: 0 ##
+  config:
+    receivers:
+      filelog/std:
+        exclude:
+        - /var/log/pods/*/otel-collector/*.log
+        - /var/log/pods/*/otc-container/*.log
+        - /var/log/pods/*/openobserve-ingester/*.log
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          output: extract_metadata_from_filepath
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - id: parser-containerd
+          output: extract_metadata_from_filepath
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - id: parser-docker
+          output: extract_metadata_from_filepath
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - cache:
+            size: 128
+          id: extract_metadata_from_filepath
+          parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.log
+          to: body
+          type: move
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        start_at: end
+      hostmetrics:
+        collection_interval: 15s
+        root_path: /hostfs
+        scrapers:
+          cpu: {}
+          disk: {}
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/.*
+              - /proc/.*
+              - /sys/.*
+              - /run/k3s/containerd/.*
+              - /var/lib/docker/.*
+              - /var/lib/kubelet/.*
+              - /snap/.*
+          load: {}
+          network: {}
+          process: {}
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 15s
+        endpoint: https://${env:K8S_NODE_NAME}:10250
+        extra_metadata_labels:
+        - container.id
+        - k8s.volume.type
+        insecure_skip_verify: true
+        metric_groups:
+        - node
+        - pod
+        - container
+        - volume
+        metrics:
+          k8s.pod.cpu_limit_utilization:
+            enabled: true
+          k8s.pod.cpu_request_utilization:
+            enabled: true
+          k8s.pod.memory_limit_utilization:
+            enabled: true
+          k8s.pod.memory_request_utilization:
+            enabled: true
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: otel-collector
+            scrape_interval: 5s
+            static_configs:
+            - targets:
+              - 0.0.0.0:8888
+    connectors:
+      {}
+    processors:
+      attributes:
+        actions:
+          - key: k8s_cluster
+            action: insert
+            value: "cluster1"
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: service.name
+          - from: pod
+            key: k8s-app
+            tag_name: service.name
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/version
+            tag_name: service.version
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          metadata:
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.deployment.name
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.start_time
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+          - from: resource_attribute
+            name: k8s.node.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+        - sources:
+          - from: connection
+      resourcedetection:
+        detectors:
+        - system
+        - env
+        - k8snode
+        override: true
+        system:
+          hostname_sources:
+          - os
+          - dns
+    extensions:
+      zpages: {}
+    exporters:
+      otlphttp/openobserve:
+        endpoint: http://o2-openobserve-standalone.openobserve.svc.cluster.local:5080/api/default
+        headers:
+          Authorization: Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=
+      otlphttp/openobserve_k8s_events:
+        endpoint: http://o2-openobserve-standalone.openobserve.svc.cluster.local:5080/api/default
+        headers:
+          Authorization: Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=
+          stream-name: k8s_events
+    service:
+      extensions:
+      - zpages
+      pipelines:
+        logs:
+          exporters:
+          - otlphttp/openobserve
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          receivers:
+          - filelog/std
+        metrics:
+          exporters:
+          - otlphttp/openobserve
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          receivers:
+          - kubeletstats
+        traces:
+          exporters:
+          - otlphttp/openobserve
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          receivers:
+          - otlp
+---
+# Source: openobserve-collector/templates/gateway.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: o2c-openobserve-collector-gateway
+  namespace: "openobserve-collector"
+  labels:
+    helm.sh/chart: openobserve-collector-0.3.21
+    app.kubernetes.io/name: openobserve-collector
+    app.kubernetes.io/instance: o2c
+    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  mode: statefulset
+  targetAllocator:
+    enabled: true
+    serviceAccount: o2c-openobserve-collector
+    prometheusCR:
+      enabled: true
+      serviceMonitorSelector: {}
+      podMonitorSelector: {}
+  serviceAccount: o2c-openobserve-collector
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0"
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  resources: 
+    {}
+  
+  # targetAllocator:
+  #   enabled: true
+  #   prometheusCR:
+  # enabled: true
+  # namespace: openobserve-collector
+  # name: prometheus
+  # port: 8888
+  config:
+    receivers:
+      k8s_cluster:
+        allocatable_types_to_report:
+        - cpu
+        - memory
+        - storage
+        collection_interval: 30s
+        metrics:
+          k8s.container.cpu_limit:
+            enabled: false
+          k8s.container.cpu_request:
+            enabled: false
+          k8s.container.memory_limit:
+            enabled: false
+          k8s.container.memory_request:
+            enabled: false
+        node_conditions_to_report:
+        - Ready
+        - MemoryPressure
+        - DiskPressure
+        - PIDPressure
+      k8s_events:
+        auth_type: serviceAccount
+      k8sobjects:
+        auth_type: serviceAccount
+        objects:
+        - field_selector: status.phase=Running
+          interval: 15m
+          mode: pull
+          name: pods
+        - group: events.k8s.io
+          mode: watch
+          name: events
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+      prometheus:
+        config:
+          scrape_configs: []
+    connectors:
+      servicegraph:
+        dimensions:
+        - http.method
+        latency_histogram_buckets:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        store:
+          max_items: 10
+          ttl: 1s
+      spanmetrics:
+        aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+        dimensions:
+        - default: GET
+          name: http.method
+        - name: http.status_code
+        dimensions_cache_size: 1000
+        exemplars:
+          enabled: true
+        histogram:
+          explicit:
+            buckets:
+            - 100us
+            - 1ms
+            - 2ms
+            - 6ms
+            - 10ms
+            - 100ms
+            - 250ms
+            - 500ms
+            - 1000ms
+            - 1400ms
+            - 2000ms
+            - 5s
+            - 10s
+            - 30s
+            - 60s
+            - 120s
+            - 300s
+            - 600s
+        metrics_flush_interval: 15s
+    processors:
+      attributes:
+        actions:
+          - key: k8s_cluster
+            action: insert
+            value: "cluster1"
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: service.name
+          - from: pod
+            key: k8s-app
+            tag_name: service.name
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/version
+            tag_name: service.version
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+          - from: resource_attribute
+            name: k8s.node.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+        - sources:
+          - from: connection
+      resourcedetection:
+        detectors:
+        - env
+        override: true
+        timeout: 2s
+    extensions:
+      zpages: {}
+    exporters:
+      otlphttp/openobserve:
+        endpoint: http://o2-openobserve-standalone.openobserve.svc.cluster.local:5080/api/default
+        headers:
+          Authorization: Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=
+      otlphttp/openobserve_k8s_events:
+        endpoint: http://o2-openobserve-standalone.openobserve.svc.cluster.local:5080/api/default
+        headers:
+          Authorization: Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM=
+          stream-name: k8s_events
+    service:
+      extensions:
+      - zpages
+      pipelines:
+        logs/k8s_events:
+          exporters:
+          - otlphttp/openobserve_k8s_events
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          - resourcedetection
+          receivers:
+          - k8s_events
+        metrics:
+          exporters:
+          - otlphttp/openobserve
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          - resourcedetection
+          receivers:
+          - k8s_cluster
+          - spanmetrics
+          - servicegraph
+        traces:
+          exporters:
+          - otlphttp/openobserve
+          - spanmetrics
+          - servicegraph
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          - resourcedetection
+          receivers:
+          - otlp

--- a/input/openobserve/README.md
+++ b/input/openobserve/README.md
@@ -1,0 +1,10 @@
+To deploy OpenObserve, Tools down below have to be deployed.
+- OpenObserve-Collector (modified version of OpenTelemetry-Collector)
+- OpenTelemetry-Operator
+- Prometheus-CRDs
+
+
+After deploying, OpenObserve is accessible by port-forwarding
+`kubectl --namespace openobserve port-forward svc/o2-openobserve-standalone 5080:5080`
+
+

--- a/input/openobserve/README.md
+++ b/input/openobserve/README.md
@@ -1,4 +1,4 @@
-To deploy OpenObserve, Tools down below have to be deployed.
+To deploy OpenObserve, Tools down below have to be deployed together.
 - OpenObserve-Collector (modified version of OpenTelemetry-Collector)
 - OpenTelemetry-Operator
 - Prometheus-CRDs
@@ -7,4 +7,4 @@ To deploy OpenObserve, Tools down below have to be deployed.
 After deploying, OpenObserve is accessible by port-forwarding
 `kubectl --namespace openobserve port-forward svc/o2-openobserve-standalone 5080:5080`
 
-
+Example queries are [here](https://openobserve.ai/docs/example-queries/)

--- a/input/openobserve/openobserve-standalone-values.yaml
+++ b/input/openobserve/openobserve-standalone-values.yaml
@@ -1,0 +1,383 @@
+# Default values for openobserve.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: public.ecr.aws/zinclabs/openobserve
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.14.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+clusterDomain: "cluster.local"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # eks.amazonaws.com/role-arn: arn:aws:iam::12345353456:role/zo-s3-eks
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+labels: {}
+
+podSecurityContext:
+  fsGroup: 2000
+  runAsUser: 10000
+  runAsGroup: 3000
+  runAsNonRoot: true
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+persistence:
+  enabled: true
+  size: 30Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  annotations: {}
+  volumePermissions:
+    enabled: false
+headless:
+  enabled: true
+  service:
+    annotations: {}
+
+# Credentials for authentication
+auth:
+  ZO_ROOT_USER_EMAIL: "root@example.com"
+  ZO_ROOT_USER_PASSWORD: "Complexpass#123"
+
+  # do not need to set this if enabled minio is being used. settings will be picked from minio section. Also IRSA is preferred if on EKS. Set the Service account section with the correct IAM role ARN. Refer https://zinc.dev/docs/guide/ha_deployment/#amazon-eks-s3
+  ZO_S3_ACCESS_KEY: ""
+  ZO_S3_SECRET_KEY: ""
+
+  AZURE_STORAGE_ACCOUNT_KEY: ""
+  AZURE_STORAGE_ACCOUNT_NAME: ""
+
+# https://openobserve.ai/docs/environment-variables/
+config:
+  ZO_APP_NAME: "openobserve"
+  ZO_CLUSTER_NAME: "o2"
+  ZO_INSTANCE_NAME: ""
+  ZO_NODE_ROLE: "all"
+  ZO_LOCAL_MODE: "true"
+  ZO_LOCAL_MODE_STORAGE: "disk"
+  ZO_HTTP_PORT: "5080"
+  ZO_HTTP_ADDR: ""
+  ZO_HTTP_IPV6_ENABLED: "false"
+  ZO_GRPC_PORT: "5081"
+  ZO_GRPC_ADDR: ""
+  ZO_GRPC_TIMEOUT: "600"
+  ZO_GRPC_MAX_MESSAGE_SIZE: "16"
+  ZO_GRPC_ORG_HEADER_KEY: "organization"
+  ZO_GRPC_STREAM_HEADER_KEY: "stream-name"
+  ZO_INTERNAL_GRPC_TOKEN: ""
+  ZO_TCP_PORT: "5514"
+  ZO_UDP_PORT: "5514"
+  ZO_DATA_DIR: "./data/"
+  ZO_DATA_DB_DIR: ""
+  ZO_DATA_WAL_DIR: ""
+  ZO_DATA_IDX_DIR: ""
+  ZO_DATA_STREAM_DIR: ""
+  ZO_DATA_CACHE_DIR: ""
+  ZO_UI_ENABLED: "true"
+  ZO_UI_SQL_BASE64_ENABLED: "false"
+  ZO_WEB_URL: ""
+  ZO_BASE_URI: ""
+  ZO_META_STORE: "sqlite"
+  ZO_META_POSTGRES_DSN: ""
+  ZO_META_MYSQL_DSN: ""
+  ZO_META_CONNECTION_POOL_MIN_SIZE: "0"
+  ZO_META_CONNECTION_POOL_MAX_SIZE: "0"
+  ZO_META_TRANSACTION_RETRIES: "3"
+  ZO_META_TRANSACTION_LOCK_TIMEOUT: "600" # seconds
+  ZO_COLUMN_TIMESTAMP: "_timestamp"
+  ZO_COLS_PER_RECORD_LIMIT: "200"
+  ZO_WIDENING_SCHEMA_EVOLUTION: "true"
+  ZO_SKIP_SCHEMA_VALIDATION: "false"
+  ZO_FEATURE_FULLTEXT_EXTRA_FIELDS: ""
+  ZO_FEATURE_DISTINCT_EXTRA_FIELDS: ""
+  ZO_FEATURE_FILELIST_DEDUP_ENABLED: "false"
+  ZO_FEATURE_QUERY_QUEUE_ENABLED: "true"
+  ZO_FEATURE_QUERY_INFER_SCHEMA: "false"
+  ZO_FEATURE_QUICK_MODE_FIELDS: "" # default fields for quick mode
+  ZO_FEATURE_QUERY_PARTITION_STRATEGY: "file_num"
+  ZO_FEATURE_PER_THREAD_LOCK: "false"
+  ZO_RESULT_CACHE_ENABLED: "false"
+  ZO_QUERY_OPTIMIZATION_NUM_FIELDS: "0"
+  ZO_QUICK_MODE_NUM_FIELDS: "500"
+  ZO_QUICK_MODE_STRATEGY: ""
+  ZO_QUICK_MODE_FILE_LIST_ENABLED: "false"
+  ZO_QUICK_MODE_FILE_LIST_INTERVAL: "300"
+  ZO_BLOOM_FILTER_ENABLED: "true"
+  ZO_BLOOM_FILTER_DEFAULT_FIELDS: ""
+  ZO_ENABLE_INVERTED_INDEX: "true"
+  ZO_INVERTED_INDEX_STORE_FORMAT: "tantivy" # InvertedIndex store format, parquet(default), tantivy, both
+  ZO_INVERTED_INDEX_SEARCH_FORMAT: "tantivy"  # InvertedIndex search format, parquet(default), tantivy.
+  ZO_INVERTED_INDEX_TANTIVY_MODE: "puffin"  # Tantivy search mode, puffin or mmap, default is puffin.
+  ZO_INVERTED_INDEX_COUNT_OPTIMIZER_ENABLED: "true"
+  ZO_FEATURE_QUERY_REMOVE_FILTER_WITH_INDEX: "true"
+  ZO_INVERTED_INDEX_SPLIT_CHARS: ""
+  ZO_FULL_TEXT_SEARCH_TYPE: "prefix"
+  ZO_QUERY_ON_STREAM_SELECTION: "true"
+  ZO_DISTINCT_VALUES_INTERVAL: "10"
+  ZO_DISTINCT_VALUES_HOURLY: "false"
+  ZO_TRACING_ENABLED: "false"
+  ZO_TRACING_SEARCH_ENABLED: "false"
+  ZO_TRACING_HEADER_KEY: "Authorization"
+  ZO_TRACING_HEADER_VALUE: "Basic cm9vdEBleGFtcGxlLmNvbTpDb21wbGV4cGFzcyMxMjM="
+  OTEL_OTLP_HTTP_ENDPOINT: ""
+  ZO_TELEMETRY: "true"
+  ZO_TELEMETRY_HEARTBEAT: "1800"
+  ZO_TELEMETRY_URL: "https://e1.zinclabs.dev"
+  ZO_JSON_LIMIT: "209715200"
+  ZO_PAYLOAD_LIMIT: "209715200"
+  ZO_PARQUET_MAX_ROW_GROUP_SIZE: "0"
+  ZO_MAX_FILE_SIZE_ON_DISK: "128"
+  ZO_MAX_FILE_SIZE_IN_MEMORY: "128"
+  ZO_MAX_FILE_RETENTION_TIME: "600"
+  ZO_FILE_PUSH_INTERVAL: "10"
+  ZO_FILE_PUSH_LIMIT: "10000"
+  ZO_FILE_MOVE_THREAD_NUM: "0"
+  ZO_FILE_MERGE_THREAD_NUM: "0"
+  ZO_MEM_DUMP_THREAD_NUM: "0"
+  ZO_MEM_TABLE_MAX_SIZE: "0"
+  ZO_MEM_TABLE_BUCKET_NUM: "0"
+  ZO_MEM_PERSIST_INTERVAL: "5"
+  ZO_ENRICHMENT_TABLE_LIMIT: "10" # size in mb
+  ZO_WAL_WRITE_BUFFER_SIZE: "16384"
+  ZO_WAL_FSYNC_DISABLED: "false"  
+  ZO_QUERY_THREAD_NUM: "0"
+  ZO_QUERY_TIMEOUT: "600"
+  ZO_ROUTE_TIMEOUT: "600"
+  ZO_ROUTE_MAX_CONNECTIONS: "1024"
+  ZO_HTTP_WORKER_NUM: "0"
+  ZO_HTTP_WORKER_MAX_BLOCKING: "0"
+  ZO_ACTIX_REQ_TIMEOUT: "30" # in second
+  ZO_ACTIX_KEEP_ALIVE: "30" # in second
+  ZO_ACTIX_SHUTDOWN_TIMEOUT: "10" # in second
+  ZO_INGEST_ALLOWED_UPTO: "24"
+  ZO_INGEST_FLATTEN_LEVEL: "3"
+  ZO_LOGS_FILE_RETENTION: "hourly"
+  ZO_TRACES_FILE_RETENTION: "hourly"
+  ZO_METRICS_FILE_RETENTION: "daily"
+  ZO_METRICS_DEDUP_ENABLED: "true"
+  ZO_METRICS_LEADER_PUSH_INTERVAL: "15"
+  ZO_METRICS_LEADER_ELECTION_INTERVAL: "30"
+  ZO_PROMETHEUS_HA_CLUSTER: "cluster"
+  ZO_PROMETHEUS_HA_REPLICA: "__replica__"
+  ZO_COMPACT_ENABLED: "true"
+  ZO_COMPACT_INTERVAL: "60"
+  ZO_COMPACT_SYNC_TO_DB_INTERVAL: "600"
+  ZO_COMPACT_STRATEGY: "file_time"
+  ZO_COMPACT_MAX_FILE_SIZE: "512"
+  ZO_COMPACT_DATA_RETENTION_DAYS: "3650"
+  ZO_COMPACT_DELETE_FILES_DELAY_HOURS: "2"
+  ZO_COMPACT_BATCH_SIZE: "100"
+  ZO_COMPACT_BLOCKED_ORGS: ""
+  ZO_MEMORY_CACHE_ENABLED: "true"
+  ZO_MEMORY_CACHE_STRATEGY: "lru"
+  ZO_MEMORY_CACHE_CACHE_LATEST_FILES: "false"
+  ZO_MEMORY_CACHE_MAX_SIZE: "0"
+  ZO_MEMORY_CACHE_SKIP_SIZE: "0"
+  ZO_MEMORY_CACHE_RELEASE_SIZE: "0"
+  ZO_MEMORY_CACHE_GC_SIZE: "50"
+  ZO_MEMORY_CACHE_GC_INTERVAL: "0"
+  ZO_MEMORY_CACHE_DATAFUSION_MEMORY_POOL: ""
+  ZO_MEMORY_CACHE_DATAFUSION_MAX_SIZE: "0"
+  ZO_DISK_CACHE_ENABLED: "true"
+  ZO_DISK_CACHE_STRATEGY: "lru"
+  ZO_DISK_CACHE_MAX_SIZE: "0"
+  ZO_DISK_CACHE_SKIP_SIZE: "0"
+  ZO_DISK_CACHE_RELEASE_SIZE: "0"
+  ZO_DISK_CACHE_GC_SIZE: "100"
+  ZO_DISK_CACHE_GC_INTERVAL: "0"
+  # ZO_S3_PROVIDER: "minio" # Need to set this up only if minio is being for object storage. Will be set automatically if enabled minio is being used.valid values are s3, azure, minio
+  ZO_S3_SERVER_URL: "" # do not need to set this if enabled minio is being used. settings will be picked from minio section
+  ZO_S3_REGION_NAME: "us-east-2" # do not need to set this if enabled minio is being used. settings will be picked from minio section
+  ZO_S3_BUCKET_NAME: "o2-dev-bucket" # do not need to set this if enabled minio is being used. settings will be picked from minio section
+  ZO_S3_BUCKET_PREFIX: ""
+  ZO_S3_FEATURE_FORCE_PATH_STYLE: "false"
+  ZO_S3_FEATURE_FORCE_HOSTED_STYLE: "false"
+  ZO_S3_FEATURE_HTTP1_ONLY: "false"
+  ZO_S3_FEATURE_HTTP2_ONLY: "false"
+  ZO_S3_SYNC_TO_CACHE_INTERVAL: "600"
+  ZO_S3_CONNECT_TIMEOUT: "10" # in seconds
+  ZO_S3_REQUEST_TIMEOUT: "3600" # in seconds
+  ZO_S3_ALLOW_INVALID_CERTIFICATES: "false"
+  ZO_S3_MAX_RETRIES: "10"
+  ZO_S3_MAX_IDLE_PER_HOST: "0"
+  ZO_USAGE_REPORTING_ENABLED: "false"
+  ZO_USAGE_REPORTING_MODE: "local"
+  ZO_USAGE_REPORTING_URL: "http://localhost:5080/api/_meta/usage/_json"
+  ZO_USAGE_REPORTING_CREDS: ""
+  ZO_USAGE_ORG: "_meta"
+  ZO_USAGE_BATCH_SIZE: "2000"
+  ZO_PRINT_KEY_CONFIG: "false"
+  ZO_PRINT_KEY_EVENT: "false"
+  ZO_PRINT_KEY_SQL: "false"
+  ZO_INGESTER_SERVICE_URL: ""
+  ZO_IGNORE_FILE_RETENTION_BY_STREAM: "false"
+  ZO_RUM_ENABLED: "false"
+  ZO_RUM_CLIENT_TOKEN: ""
+  ZO_RUM_APPLICATION_ID: ""
+  ZO_RUM_SITE: ""
+  ZO_RUM_SERVICE: ""
+  ZO_RUM_ENV: ""
+  ZO_RUM_VERSION: "0.9.1"
+  ZO_RUM_ORGANIZATION_IDENTIFIER: "default"
+  ZO_RUM_API_VERSION: "v1"
+  ZO_RUM_INSECURE_HTTP: "false"
+  ZO_COOKIE_MAX_AGE: "2592000" # 30 days
+  ZO_COOKIE_SAME_SITE_LAX: "true"
+  ZO_COOKIE_SECURE_ONLY: "false"
+  ZO_PROF_PYROSCOPE_ENABLED: "false"
+  ZO_PROF_PYROSCOPE_SERVER_URL: "http://localhost:4040"
+  ZO_PROF_PYROSCOPE_PROJECT_NAME: "openobserve"
+  ZO_ENTRY_PER_SCHEMA_VERSION_ENABLED: "true"
+  RUST_LOG: "info"
+  RUST_BACKTRACE: "0"
+
+# Add extra environment variables to all pods, useful for overriding secrets
+extraEnv: []
+# - name: ZO_S3_SECRET_KEY
+#   valueFrom:
+#     secretKeyRef:
+#       name: s3credentials-secret
+#       key: S3_KEY
+
+service:
+  type: ClusterIP
+  # type: LoadBalancer
+  http_port: 5080
+  grpc_port: 5081
+  annotations: {}
+
+certIssuer:
+  enabled: false
+
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations:
+    cert-manager.io/issuer: letsencrypt
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    # nginx.ingress.kubernetes.io/connection-proxy-header: keep-alive
+    # nginx.ingress.kubernetes.io/proxy-connect-timeout: '600'
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: '600'
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: '600'
+    # nginx.ingress.kubernetes.io/proxy-body-size: 32m
+  hosts:
+    - host: openobserve.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: openobserve.example.com
+      hosts:
+        - openobserve.example.com
+
+# You can specify resources for each deployment independently.
+# For example, to configure resources for the ingester, use
+# the code below:
+# resources:
+#   ingester:
+#     limits:
+#       cpu: 150m
+#       memory: 512Mi
+#     requests:
+#       cpu: 100m
+#       memory: 128Mi
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# https://github.com/minio/minio/blob/master/helm/minio/values.yaml
+minio:
+  enabled: false # if true then minio will be deployed as part of openobserve
+  region: "us-east-1"
+  rootUser: rootuser
+  rootPassword: rootpass123
+  drivesPerNode: 1
+  replicas: 4
+  mode: distributed # or standalone
+  image:
+    repository: quay.io/minio/minio
+    tag: RELEASE.2023-02-10T18-48-39Z
+    pullPolicy: IfNotPresent
+  mcImage:
+    repository: quay.io/minio/mc
+    tag: RELEASE.2023-01-28T20-29-38Z
+    pullPolicy: IfNotPresent
+  buckets:
+    - name: mysuperduperbucket
+      policy: none
+      purge: false
+  resources:
+    requests:
+      memory: 256Mi
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    annotations: {}
+
+# zPlane enables elasticsearch compatibility for openobserve. Copyright (c) 2023 Zinc Labs Inc.
+# You can enable zPlane by setting enabled to true
+# zPlane is a commercial software and requires a license to be used.
+# Reach out to hello@zinclabs.io for commercial license if you continue to use zPlane
+zplane:
+  enabled: false # if true then zPlane will be deployed as part of openobserve
+  image:
+    repository: public.ecr.aws/zinclabs/zplane
+    tag: 0.1.6
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 9200
+    annotations: {}
+  ingress: # if enabled is true then this is required
+    enabled: false
+    className: ""
+    annotations:
+      {}
+      # kubernetes.io/ingress.class: nginx
+      # cert-manager.io/issuer: letsencrypt
+      # kubernetes.io/tls-acme: true
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      []
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+
+probes:
+  enabled: true
+  initialDelaySeconds: 10
+  failureThreshold: 3
+  path: /healthz


### PR DESCRIPTION
For [issue 96](https://github.com/silogen/platform/issues/96).

This PR adds OpenObserve and required tools to cluster-forge. OpenObserve works as a backend giving much less footprints compared to deploying all Grafana-Mimir, Grafana-Loki, and Grafana-Tempo.

Included tools this PR are:
- OpenObserve
- OpenObserve-Collector (modified version of OpenTelemetry-Collector)
- OpenTelemetry-Operator
- Promttheus-CRDs

After deploying, OpenObserve is accessible by port-forwarding
```
kubectl --namespace openobserve port-forward svc/o2-openobserve-standalone 5080:5080
```
