### PR TITLE
Add otel-lgtm-stack to cluster-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To create a stack without the forge command, or for further instructions and opt
 ## Instruction of deploying monitoring tools
 - [OpenObserve](input/openobserve/README.md)
 - [Prometheus-Operator](input/kube-prometheus-stack/README.md)
+- [otel-lgtm-stack](input/otel-lgtm-stack/README.md)
 
 ## Instruction of other tools
 - [k8s-cluster-secret-store](input/k8s-cluster-secret-store/README.md)

--- a/input/config.yaml
+++ b/input/config.yaml
@@ -161,3 +161,6 @@
 - name: kaiwo-cluster-config
   namespace: kaiwo
   sourcefile: kaiwo-cluster-config/manifests.yaml
+- name: otel-lgtm-stack
+  namespace: otel-lgtm-stack
+  sourcefile: otel-lgtm-stack/otel-lgtm-manifests.yaml 

--- a/input/otel-lgtm-stack/README.md
+++ b/input/otel-lgtm-stack/README.md
@@ -8,7 +8,10 @@
 - otel-lgtm
 
 # How this otel-collector manifests created
-This otel-collector(agent) manifests are created from the modification of openobserve-collector manifests. Collector(agent) acting like node-exporter sends telemetries to the endpoint of otel-collector(gateway) which is a component of otel-lgtm stack. Current instrumentations are configured to send telemetries to the endpoint of otel-lgtm. Users/Developers who want to use auto instrumation need to implement by giving an annotation to their pods.
+This otel-collector(agent) manifests are created from the modification of openobserve-collector manifests. 
+Collector(agent) acting like node-exporter sends telemetries to the endpoint of otel-collector(gateway) which is a component of otel-lgtm stack. 
+Current instrumentations are configured to send telemetries to the endpoint of otel-lgtm. 
+Users/Developers who want to use auto instrumation need to implement by giving an annotation to their pods.
 
 # Source of otel-lgtm stack
 - https://github.com/grafana/docker-otel-lgtm/tree/main

--- a/input/otel-lgtm-stack/README.md
+++ b/input/otel-lgtm-stack/README.md
@@ -1,0 +1,19 @@
+# Required tools
+- cert-manager
+- opentelemetry-operator
+- prometheus-crds
+
+# This tool consists of
+- otel-collector(agent)
+- otel-lgtm
+
+# How this otel-collector manifests created
+This otel-collector(agent) manifests are created from the modification of openobserve-collector manifests. Collector(agent) acting like node-exporter sends telemetries to the endpoint of otel-collector(gateway) which is a component of otel-lgtm stack. Current instrumentations are configured to send telemetries to the endpoint of otel-lgtm. Users/Developers who want to use auto instrumation need to implement by giving an annotation to their pods.
+
+# Source of otel-lgtm stack
+- https://github.com/grafana/docker-otel-lgtm/tree/main
+
+# After deployment
+kubectl port-forward -n otel-lgtm-stack service/lgtm-stack 3000:3000 4317:4317 4318:4318
+
+id/password of grafana: admin/admin

--- a/input/otel-lgtm-stack/otel-lgtm-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-lgtm-manifests.yaml
@@ -1,0 +1,599 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  name: otel-lgtm-stack
+---
+## lgtm-collector
+# Source: openobserve-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lgtm-collector
+  namespace: otel-lgtm-stack
+  labels:
+    #helm.sh/chart: openobserve-collector-0.3.21
+    app.kubernetes.io/name: lgtm-collector
+    app.kubernetes.io/instance: o2c
+    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: openobserve-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lgtm-collector
+  labels:
+    app: lgtm-collector
+rules:
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/metrics
+  - nodes/proxy
+  - persistentvolumes
+  - persistentvolumeclaims
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  - podmonitors
+  - probes
+  - scrapeconfigs
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  - cronjobs
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+    - horizontalpodautoscalers
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs: ["get", "list", "watch"]
+---
+# Source: openobserve-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lgtm-collector
+  labels:
+    app: lgtm-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lgtm-collector
+subjects:
+- kind: ServiceAccount
+  name: lgtm-collector
+  namespace: otel-lgtm-stack
+---
+# Source: openobserve-collector/templates/instrumentation-dotnet.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-dotnet
+  namespace: otel-lgtm-stack
+spec:
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ###
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  dotnet:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+---
+# Source: openobserve-collector/templates/instrumentation-go.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-go
+  namespace: otel-lgtm-stack
+spec:
+  go:
+    # image: ghcr.io/openobserve/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.7.0-alpha-5
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.19.0-alpha
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ##
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+---
+# Source: openobserve-collector/templates/instrumentation-java.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-java
+  namespace: otel-lgtm-stack
+spec:
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ###
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  java:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+---
+# Source: openobserve-collector/templates/instrumentation-nodejs.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-nodejs
+  namespace: otel-lgtm-stack
+spec:
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ###
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+---
+# Source: openobserve-collector/templates/instrumentation-python.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-python
+  namespace: otel-lgtm-stack
+spec:
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ###
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  python:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_LOGS_EXPORTER
+        value: otlp_proto_http
+      - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+        value: "false" # set to true to enable auto instrumentation for logs
+---
+# Source: openobserve-collector/templates/agent.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: lgtm-collector-agent ###
+  namespace: otel-lgtm-stack ###
+  labels: ###
+    #helm.sh/chart: openobserve-collector-0.3.21 
+    app.kubernetes.io/name: lgtm-collector
+    app.kubernetes.io/instance: o2c
+    app.kubernetes.io/version: "0.113.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  mode: daemonset # "daemonset", "deployment" (default), "statefulset"
+  serviceAccount: lgtm-collector ###
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0"
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  tolerations:
+        - effect: NoSchedule
+          key: exampleKey1
+          operator: Equal
+          value: "true"
+  volumes:
+    - name: hostfs
+      hostPath:
+        path: /
+    - name: varlog
+      hostPath:
+        path: /var/log
+        type: ''
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+        type: ''
+  volumeMounts:
+    - name: hostfs
+      mountPath: /hostfs
+    - name: varlog
+      mountPath: /var/log
+    - name: varlibdockercontainers
+      readOnly: true
+      mountPath: /var/lib/docker/containers
+  resources:
+    {}
+  securityContext: ##
+    runAsUser: 0 ##
+    runAsGroup: 0 ##
+  config:
+    receivers:
+      filelog/std:
+        exclude:
+        - /var/log/pods/*/otel-collector/*.log
+        - /var/log/pods/*/otc-container/*.log
+        - /var/log/pods/*/openobserve-ingester/*.log
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          output: extract_metadata_from_filepath
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - id: parser-containerd
+          output: extract_metadata_from_filepath
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - id: parser-docker
+          output: extract_metadata_from_filepath
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - cache:
+            size: 128
+          id: extract_metadata_from_filepath
+          parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.log
+          to: body
+          type: move
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        start_at: end
+      hostmetrics:
+        collection_interval: 15s
+        root_path: /hostfs
+        scrapers:
+          cpu: {}
+          disk: {}
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/.*
+              - /proc/.*
+              - /sys/.*
+              - /run/k3s/containerd/.*
+              - /var/lib/docker/.*
+              - /var/lib/kubelet/.*
+              - /snap/.*
+          load: {}
+          network: {}
+          process: {}
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 15s
+        endpoint: https://${env:K8S_NODE_NAME}:10250
+        extra_metadata_labels:
+        - container.id
+        - k8s.volume.type
+        insecure_skip_verify: true
+        metric_groups:
+        - node
+        - pod
+        - container
+        - volume
+        metrics:
+          k8s.pod.cpu_limit_utilization:
+            enabled: true
+          k8s.pod.cpu_request_utilization:
+            enabled: true
+          k8s.pod.memory_limit_utilization:
+            enabled: true
+          k8s.pod.memory_request_utilization:
+            enabled: true
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: lgtm-collector
+            scrape_interval: 5s
+            static_configs:
+            - targets:
+              - 0.0.0.0:8888
+    connectors:
+      {}
+    processors:
+      attributes:
+        actions:
+          - key: k8s_cluster
+            action: insert
+            value: "cluster1"
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: service.name
+          - from: pod
+            key: k8s-app
+            tag_name: service.name
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/version
+            tag_name: service.version
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          metadata:
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.deployment.name
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.start_time
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+          - from: resource_attribute
+            name: k8s.node.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+        - sources:
+          - from: connection
+      resourcedetection:
+        detectors:
+        - system
+        - env
+        - k8snode
+        override: true
+        system:
+          hostname_sources:
+          - os
+          - dns
+    extensions:
+      zpages: {}
+    exporters:
+      otlphttp/lgtm-stack:
+        endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4318
+      otlphttp/k8s_events:
+        endpoint: http:/lgtm-stack.otel-lgtm-stack.svc.cluster.local:4318
+        headers:
+          stream-name: k8s_events
+    service:
+      extensions:
+      - zpages
+      pipelines:
+        logs:
+          exporters:
+          - otlphttp/lgtm-stack
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          receivers:
+          - filelog/std
+        metrics:
+          exporters:
+          - otlphttp/lgtm-stack
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          receivers:
+          - kubeletstats
+        traces:
+          exporters:
+          - otlphttp/lgtm-stack
+          processors:
+          - batch
+          - attributes
+          - k8sattributes
+          receivers:
+          - otlp
+---
+# this is intended for demo / testing purposes only, not for production usage
+apiVersion: v1
+kind: Service
+metadata:
+  name: lgtm-stack
+  namespace: otel-lgtm-stack
+spec:
+  selector:
+    app: lgtm
+  ports:
+    - name: grafana
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+    - name: otel-grpc
+      protocol: TCP
+      port: 4317
+      targetPort: 4317
+    - name: otel-http
+      protocol: TCP
+      port: 4318
+      targetPort: 4318
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lgtm
+  namespace: otel-lgtm-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lgtm
+  template:
+    metadata:
+      labels:
+        app: lgtm
+    spec:
+      containers:
+        - name: lgtm
+          image: grafana/otel-lgtm:latest
+          ports:
+            - containerPort: 3000
+            - containerPort: 4317
+            - containerPort: 4318
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/ready
+          # NOTE: By default OpenShift does not allow writing the root directory.
+          # Thats why the data dirs for grafana, prometheus and loki can not be
+          # created and the pod never becomes ready.
+          # See: https://github.com/grafana/docker-otel-lgtm/issues/132
+          volumeMounts:
+            - name: tempo-data
+              mountPath: /data/tempo
+            - name: grafana-data
+              mountPath: /data/grafana
+            - name: loki-data
+              mountPath: /data/loki
+            - name: loki-storage
+              mountPath: /loki
+            - name: p8s-storage
+              mountPath: /data/prometheus
+      volumes:
+        - name: tempo-data
+          emptyDir: {}
+        - name: loki-data
+          emptyDir: {}
+        - name: grafana-data
+          emptyDir: {}
+        - name: loki-storage
+          emptyDir: {}
+        - name: p8s-storage
+          emptyDir: {}


### PR DESCRIPTION
This PR adds otel-lgtm-stack to cluster-forge.

Copied from README as follows:
```
# Required tools
- cert-manager
- opentelemetry-operator
- prometheus-crds

# This tool consists of
- otel-collector(agent)
- otel-lgtm

# How this otel-collector manifests created
This otel-collector(agent) manifests are created from the modification of openobserve-collector manifests. 
Collector(agent) acting like node-exporter sends telemetries to the endpoint of otel-collector(gateway) which is a component of otel-lgtm stack. 
Current instrumentations are configured to send telemetries to the endpoint of otel-lgtm. 
Users/Developers who want to use auto instrumation need to implement by giving an annotation to their pods.

# Source of otel-lgtm stack
- https://github.com/grafana/docker-otel-lgtm/tree/main

# After deployment
kubectl port-forward -n otel-lgtm-stack service/lgtm-stack 3000:3000 4317:4317 4318:4318

id/password of grafana: admin/admin
```

