### PR TITLE
edit mimir and delete a part of dummy-secret

### DIFF
--- a/input/config.yaml
+++ b/input/config.yaml
@@ -137,6 +137,7 @@
   name: grafana-mimir
   namespace: "grafana-mimir"
   helm-version: "5.2.1"
+  syncwave: 1
 - helm-chart-name: "redis"
   helm-name: redis
   helm-url: "https://charts.bitnami.com/bitnami"

--- a/input/dummy-secret/dummy-secret-monitoring-tools.yaml
+++ b/input/dummy-secret/dummy-secret-monitoring-tools.yaml
@@ -17,36 +17,3 @@ type: Opaque
 data:
   grafana-admin-id: YWRtaW4= # This is base64 encoded "admin"
   grafana-admin-pw: cGFzc3dvcmQ= # This is base64 encoded "password"
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: minio-user-credential
-  namespace: minio
-type: Opaque
-data:
-  password: QTEyM2V4YW1wbGVzZWNyZXRwYXNzd29yZA==  # This is base64 encoded "A123examplesecretpassword"
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: loki-minio-creds
-  namespace: grafana-loki
-type: Opaque
-data:
-  access_key_id: ZXh0ZXJuYWxTZWNyZXQ= # This is base64 encoded "externalSecret"
-  #access_key_id: QTEyM2V4YW1wbGVzZWNyZXRwYXNzd29yZA==  # This is base64 encoded "A123examplesecretpassword"
-  secret_access_key: QTEyM2V4YW1wbGVzZWNyZXRwYXNzd29yZA==  # This is base64 encoded "A123examplesecretpassword"
-  loki_tenant_pw_demo: QTEyM2V4YW1wbGVzZWNyZXRwYXNzd29yZA== # This is base64 encoded "A123examplesecretpassword"
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mimir-minio-creds
-  namespace: grafana-mimir
-type: Opaque
-data:
-  access_key_id: ZXh0ZXJuYWxTZWNyZXQ= # This is base64 encoded "externalSecret"
-  #access_key_id: QTEyM2V4YW1wbGVzZWNyZXRwYXNzd29yZA==  # This is base64 encoded "A123examplesecretpassword"
-  secret_access_key: QTEyM2V4YW1wbGVzZWNyZXRwYXNzd29yZA==  # This is base64 encoded "A123examplesecretpassword"
-  .htpasswd: Y2x1c3Rlci1mb3JnZS1taW1pci10ZXN0LXVzZXI6JGFwcjEkbXN6R0hSZnUkZkRDaUEzMm9SZHRQOHRYR1RUbjJNMAo= # This is base64 encoded "cluster-forge-mimir-test-user:\$apr1\$mszGHRfu\$fDCiA32oRdtP8tXGTTn2M0" # Created from "htpasswd -cb htpasswd cluster-forge-mimir-test-user cluster-forge-mimir-test-pass"

--- a/input/grafana-mimir/grafana-mimir-values.yaml
+++ b/input/grafana-mimir/grafana-mimir-values.yaml
@@ -83,7 +83,7 @@ alertmanager:
 compactor:
   persistentVolume:
     size: 5Gi
-    storageClass: standard 
+    storageClass: longhorn-default 
     #size: 20Gi
   resources:
     limits:
@@ -104,7 +104,7 @@ distributor:
 ingester:
   persistentVolume:
     size: 5Gi
-    storageClass: standard
+    storageClass: longhorn-default
     #size: 50Gi
   replicas: 3
   resources:

--- a/input/grafana-mimir/grafana-mimir-values.yaml
+++ b/input/grafana-mimir/grafana-mimir-values.yaml
@@ -25,16 +25,16 @@
 global:
   extraEnv:
 ## Access buckets
-    - name: ACCESS_KEY_ID
+    - name: API_ACCESS_KEY
       valueFrom:
         secretKeyRef:
           name: mimir-minio-creds
-          key: access_key_id
-    - name: SECRET_ACCESS_KEY
+          key: API_ACCESS_KEY
+    - name: API_SECRET_KEY
       valueFrom:
         secretKeyRef:
           name: mimir-minio-creds
-          key: secret_access_key
+          key: API_SECRET_KEY
 
 mimir:
   structuredConfig:
@@ -42,27 +42,26 @@ mimir:
       storage:
         backend: s3
         s3:
-          #endpoint: http://minio.minio.svc.cluster.local:9000
-          endpoint: minio.minio.svc.cluster.local:9000
-          secret_access_key: "${SECRET_ACCESS_KEY}" # This is a secret injected via an environment variable ###
-          access_key_id: "${ACCESS_KEY_ID}" # This is a secret injected via an environment variable ###
-          insecure: true ## for toy minio 
+          endpoint: minio.minio-tenant-default.svc.cluster.local:443 ####
+          secret_access_key: "${API_SECRET_KEY}" ####
+          access_key_id: "${API_ACCESS_KEY}" ####
+          insecure: false ## for toy minio #########
           http:
             insecure_skip_verify: true
 
     blocks_storage:
       backend: s3
       s3:
-        bucket_name: cluster-forge-mimir-test-dummy ###
-        insecure: true ##
+        bucket_name: cluster-forge-mimir
+        insecure: false ##
     alertmanager_storage: ##
       s3:
-        bucket_name: cluster-forge-mimir-test-dummy ###
-        insecure: true ##
+        bucket_name: cluster-forge-mimir
+        insecure: false ##
     ruler_storage: ##
       s3:
-        bucket_name: cluster-forge-mimir-test-dummy ###
-        insecure: true ##
+        bucket_name: cluster-forge-mimir
+        insecure: false ##
     limits:
       max_label_names_per_series: 50
       max_global_series_per_user: 1000000
@@ -84,6 +83,7 @@ alertmanager:
 compactor:
   persistentVolume:
     size: 5Gi
+    storageClass: standard 
     #size: 20Gi
   resources:
     limits:
@@ -104,6 +104,7 @@ distributor:
 ingester:
   persistentVolume:
     size: 5Gi
+    storageClass: standard
     #size: 50Gi
   replicas: 3
   resources:
@@ -240,7 +241,7 @@ gateway:
       #username: ${BASICAUTH_USERNAME} #Passing basic auth info doesn't work
       #password: ${BASICAUTH_PASSWORD} #Passing .htpasswd via existingSecret works
       #existingSecret: mimir-credentials ###
-      existingSecret: mimir-minio-creds  ###
+      existingSecret: mimir-minio-creds ##nginx  htpasswd
 
 query_scheduler:
   enabled: true
@@ -261,3 +262,25 @@ query_scheduler:
 nginx:
   enabled: false
 
+extraObjects:
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: mimir-minio-creds
+      namespace: grafana-mimir
+    spec:
+      refreshInterval: "30m"
+      secretStoreRef:
+        name: k8s-secret-store
+        kind: ClusterSecretStore
+      target:
+        name: mimir-minio-creds
+      data:
+        - secretKey: API_ACCESS_KEY
+          remoteRef:
+            key: default-user
+            property: API_ACCESS_KEY
+        - secretKey: API_SECRET_KEY
+          remoteRef:
+            key: default-user
+            property: API_SECRET_KEY

--- a/input/k8s-cluster-secret-store/manifests.yaml
+++ b/input/k8s-cluster-secret-store/manifests.yaml
@@ -82,6 +82,9 @@ spec:
       - key: loki_tenant_password
         value: loki-tenant-demo-password
         version: v1
+      - key: .htpasswd
+        value: cluster-forge-mimir-test-user:$apr1$mszGHRfu$fDCiA32oRdtP8tXGTTn2M0 #Created from "htpasswd -cb htpasswd cluster-forge-mimir-test-user cluster-forge-mimir-test-pass"
+        version: v1
 ---
 apiVersion: generators.external-secrets.io/v1alpha1
 kind: Password


### PR DESCRIPTION
The result of this PR is a part of replacing "dummy-secret" with external-secrets.
This PR makes "grafana-mimir" could work with "minio-tenant" and "external-secerts". 
(previously, it worked with insecure "minio-standard" with dummy-secrets)

"dummy-secret" will be completely removed after updating "promtail" and "grafana"