### PR TITLE
Update workflow to add ingress to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,12 +73,14 @@ jobs:
           mv stacks/${{ github.event.inputs.version }}-${{ matrix.release.type }} stacks/${PACKAGE_DIR}/
           mkdir -p stacks/longhorn
           cp -r setup-cluster/longhorn/ stacks/
+          mkdir -p stacks/ingress
+          cp -r setup-cluster/ingress stacks/
           cp setup-cluster/setup-forge.sh stacks/
 
       - name: Create tarball
         run: |
           PACKAGE_DIR="clusterforge-${{ matrix.release.type }}-${{ github.event.inputs.version }}"
-          tar -C stacks/ -zcvf stacks/release-${{ matrix.release.type }}-${{ github.event.inputs.version }}.tar.gz ${PACKAGE_DIR} longhorn/ setup-forge.sh
+          tar -C stacks/ -zcvf stacks/release-${{ matrix.release.type }}-${{ github.event.inputs.version }}.tar.gz ${PACKAGE_DIR} longhorn/ ingress/ setup-forge.sh
 
       - name: Create release
         if: github.ref == 'refs/heads/main'

--- a/setup-cluster/setup-forge.sh
+++ b/setup-cluster/setup-forge.sh
@@ -299,7 +299,7 @@ main() {
         sudo sed "s/127\.0\.0\.1/$MAIN_IP/g" /etc/rancher/rke2/rke2.yaml | tee $HOME/.kube/config
         chmod 600 $HOME/.kube/config
         wait_for_api_server 
-				sudo sed -i "s/{{CONTROL_IP}}/$MAIN_IP/g" ingress/ingress.yaml
+		sudo sed -i "s/{{CONTROL_IP}}/$MAIN_IP/g" ingress/ingress.yaml
         KUBECONFIG=$HOME/.kube/config && bash deploy.sh
         gum log --structured --level info 'ClusterForge installed'
         
@@ -311,7 +311,7 @@ main() {
         echo "export TOKEN=$TOKEN; export SERVER_IP=$MAIN_IP; curl https://silogen.github.io/cluster-forge/deploy.sh | sudo bash"
         echo ---
     fi
-		wait_for_namespaces
+	wait_for_namespaces
     KUBECONFIG==$HOME/.kube/config kubectl apply -f ingress/ingress.yaml
     gum log --structured --level info "Server setup successfully!"
 

--- a/setup-cluster/setup-forge.sh
+++ b/setup-cluster/setup-forge.sh
@@ -193,6 +193,28 @@ wait_for_api_server() {
     gum log --structured --level info "Kubernetes API server is ready"
 }
 
+wait_for_namespaces() {
+    local max_attempts=30
+    local attempt=1
+    local namespaces=("longhorn" "cf-gitea" "minio-tenant-default" "otel-lgtm-stack")
+
+    for ns in "${namespaces[@]}"; do
+        gum log --structured --level info "Waiting for namespace $ns to be ready..."
+
+        while ! kubectl get namespace "$ns" &>/dev/null; do
+            if [ $attempt -ge $max_attempts ]; then
+                gum log --structured --level error "Timeout waiting for namespace $ns to become ready"
+                return 1
+            fi
+            gum log --structured --level debug "Waiting for namespace $ns (attempt $attempt/$max_attempts)..."
+            sleep 10 
+            ((attempt++))
+        done
+        gum log --structured --level info "Namespace $ns is ready"
+    done
+    return 0
+}
+
 setup_rke2_additional() {
   RKE2_SERVER_URL="https://get.rke2.io"
   RKE2_CONFIG_PATH="/etc/rancher/rke2/config.yaml"
@@ -276,9 +298,8 @@ main() {
         mkdir -p $HOME/.kube
         sudo sed "s/127\.0\.0\.1/$MAIN_IP/g" /etc/rancher/rke2/rke2.yaml | tee $HOME/.kube/config
         chmod 600 $HOME/.kube/config
-        sudo sed -i "s/{{CONTROL_IP}}/$MAIN_IP/g" ingress/ingress.yaml
-        KUBECONFIG=/etc/rancher/rke2/rke2.yaml kubectl apply -f ingress/ingress.yaml
         wait_for_api_server 
+				sudo sed -i "s/{{CONTROL_IP}}/$MAIN_IP/g" ingress/ingress.yaml
         KUBECONFIG=$HOME/.kube/config && bash deploy.sh
         gum log --structured --level info 'ClusterForge installed'
         
@@ -290,6 +311,8 @@ main() {
         echo "export TOKEN=$TOKEN; export SERVER_IP=$MAIN_IP; curl https://silogen.github.io/cluster-forge/deploy.sh | sudo bash"
         echo ---
     fi
+		wait_for_namespaces
+    KUBECONFIG==$HOME/.kube/config kubectl apply -f ingress/ingress.yaml
     gum log --structured --level info "Server setup successfully!"
 
 }

--- a/setup-cluster/setup-forge.sh
+++ b/setup-cluster/setup-forge.sh
@@ -299,7 +299,7 @@ main() {
         sudo sed "s/127\.0\.0\.1/$MAIN_IP/g" /etc/rancher/rke2/rke2.yaml | tee $HOME/.kube/config
         chmod 600 $HOME/.kube/config
         wait_for_api_server 
-		sudo sed -i "s/{{CONTROL_IP}}/$MAIN_IP/g" ingress/ingress.yaml
+        sudo sed -i "s/{{CONTROL_IP}}/$MAIN_IP/g" ingress/ingress.yaml
         KUBECONFIG=$HOME/.kube/config && bash deploy.sh
         gum log --structured --level info 'ClusterForge installed'
         
@@ -311,7 +311,7 @@ main() {
         echo "export TOKEN=$TOKEN; export SERVER_IP=$MAIN_IP; curl https://silogen.github.io/cluster-forge/deploy.sh | sudo bash"
         echo ---
     fi
-	wait_for_namespaces
+    wait_for_namespaces
     KUBECONFIG==$HOME/.kube/config kubectl apply -f ingress/ingress.yaml
     gum log --structured --level info "Server setup successfully!"
 


### PR DESCRIPTION
This PR updates workflow to add ingress to release and add wait_for_namespaces function to setup-forge.sh script before applying ingress.yaml line. I guess that 300 seconds for checking the existence of each namespace will be enough based on my experience observing the argocd app so far.

The order will be...
- run `sudo sed -i "s/{{CONTROL_IP}}/$MAIN_IP/g" ingress/ingress.yaml`  inside if clause to use `$MAIN_IP`
- run `wait_for_namespaces function`
- run `KUBECONFIG==$HOME/.kube/config kubectl apply -f ingress/ingress.yaml` outside of if clause
