### PR TITLE
add resources.requests and resources.limits for lgtm stack

### DIFF
--- a/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
@@ -212,7 +212,6 @@ spec:
               cpu: "500m"
               memory: "1024Mi"
             limits:
-              cpu: "2000m"
               memory: "2Gi"
           # NOTE: By default OpenShift does not allow writing the root directory.
           # Thats why the data dirs for grafana, prometheus and loki can not be

--- a/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
@@ -207,6 +207,13 @@ spec:
               command:
                 - cat
                 - /tmp/ready
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1024Mi"
+            limits:
+              cpu: "2000m"
+              memory: "2Gi"
           # NOTE: By default OpenShift does not allow writing the root directory.
           # Thats why the data dirs for grafana, prometheus and loki can not be
           # created and the pod never becomes ready.


### PR DESCRIPTION
This PR adds requests and limits of resources to LGTM stack.
LGTM-stack was blocked on a cluster having kyverno policy.

It could be good that numbers of requests and limits updated later on based on actual usages.