### PR TITLE
Delete a manifest creating external-secrets namespace

### DIFF
--- a/input/1password-cluster-secret-store/manifests/Namespace_1password-cluster-secret-store.yaml
+++ b/input/1password-cluster-secret-store/manifests/Namespace_1password-cluster-secret-store.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: external-secrets


### PR DESCRIPTION
This PR deletes a manifest in 1password-cluster-secret-store folder, which creates a "external-secret" namespace.
This gets rid of "out of sync" from the both "external-secret" and "1password-cluster-secret" tools trying to handle "external-secret" namespace.

From now on, "external-secret"(syncwave: -1) tool should be deployed together with "1password-cluster-secret-store"(syncwave: 0). Otherwise, it will fail to deploy "input/1password-cluster-secret-store/manifests/Service_central-onepass-connect.yaml"