### PR TITLE
Add recreate strategy to lgtm deployment

### DIFF
--- a/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
@@ -153,6 +153,8 @@ metadata:
   namespace: otel-lgtm-stack
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: lgtm


### PR DESCRIPTION
This PR will solve an issue of deployment controlled by argocd app. Previously deployed lgtm pod holds PVC and PV so newly created lgtm pod cannot be up until old one disappears.