### PR TITLE
expose prometheus as a service

### DIFF
--- a/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
@@ -145,6 +145,10 @@ spec:
       protocol: TCP
       port: 4318
       targetPort: 4318
+    - name: prometheys
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -204,6 +208,7 @@ spec:
             - containerPort: 3000
             - containerPort: 4317
             - containerPort: 4318
+            - containerPort: 9090
           readinessProbe:
             exec:
               command:

--- a/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-lgtm/modified-manifests.yaml
@@ -145,7 +145,7 @@ spec:
       protocol: TCP
       port: 4318
       targetPort: 4318
-    - name: prometheys
+    - name: prometheus
       protocol: TCP
       port: 9090
       targetPort: 9090


### PR DESCRIPTION
Prometheus is included in the LGTM stack image, but is not exposed. This PR adds the Prometheus port to the LGTM deployment and service.