### PR TITLE
Update otel collectors of lgtm for inter-cluster exporting of telemetries

### DIFF
--- a/input/grafana-mimir/grafana-mimir-values.yaml
+++ b/input/grafana-mimir/grafana-mimir-values.yaml
@@ -238,7 +238,7 @@ gateway:
       #username: ${BASICAUTH_USERNAME} #Passing basic auth info doesn't work
       #password: ${BASICAUTH_PASSWORD} #Passing .htpasswd via existingSecret works
       #existingSecret: mimir-credentials ###
-      existingSecret: mimir-minio-creds ##nginx  htpasswd
+      existingSecret: mimir-tenant-creds ##nginx  htpasswd
     config:
       resolver: rke2-coredns-rke2-coredns.kube-system.svc.cluster.local
 
@@ -283,3 +283,21 @@ extraObjects:
           remoteRef:
             key: default-user
             property: API_SECRET_KEY
+
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: mimir-tenant-creds-from-fake
+      namespace: grafana-mimir
+    spec:
+      refreshInterval: "30m"
+      secretStoreRef:
+        name: fake-secret-store
+        kind: ClusterSecretStore
+      target:
+        name: mimir-tenant-creds
+      data:
+        - secretKey: .htpasswd
+          remoteRef:
+            key: .htpasswd
+            version: v1

--- a/input/grafana/grafana-values.yaml
+++ b/input/grafana/grafana-values.yaml
@@ -68,9 +68,9 @@ datasources:
       orgId: 1
       uid: loki_for_logs
       basicAuth: true
-      basicAuthUser: loki-tenant-demo
+      basicAuthUser: loki_tenant_demo
       secureJsonData:
-        basicAuthPassword: A123examplesecretpassword ###
+        basicAuthPassword: loki-tenant-demo-password ###
     - name: Mimir ###
       type: prometheus
       url: http://mimir-gateway.grafana-mimir.svc:8080/prometheus ###
@@ -81,7 +81,7 @@ datasources:
       basicAuthUser: cluster-forge-mimir-test-user
       secureJsonData:
         basicAuthPassword:  cluster-forge-mimir-test-pass ###
-        httpHeaderValue1: 'mimir-tenant' ###
+        httpHeaderValue1: 'mimir-tenant-ociops' ###
       jsonData:
         httpHeaderName1: 'X-Scope-OrgID'
     - name: Prometheus-operator ###

--- a/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
@@ -811,6 +811,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      attributes:
+        actions:
+          - key: k8s_cluster_name
+            action: insert
+            value: "ociops" ### value should be updated based on cluster
 
     extensions: ##
       basicauth/mimir-tenant:

--- a/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
@@ -846,7 +846,7 @@ spec:
         metrics:
           receivers: [prometheus]
           processors: [memory_limiter, batch]
-          exporters: [otlp]
+          exporters: [otlp, otlphttp/ops-mimir]
           #exporters: [otlp, debug]
   volumeMounts:
     - name: htpasswd-volume

--- a/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
@@ -313,9 +313,9 @@ spec:
     processors:
       attributes:
         actions:
-          - key: k8s_cluster
+          - key: k8s_cluster_name
             action: insert
-            value: "cluster1"
+            value: "ociops" ### value should be updated based on cluster
       batch:
         send_batch_size: 2000
         timeout: 10s
@@ -385,23 +385,38 @@ spec:
         - env
         override: true
         timeout: 2s
-    
+
+    extensions: ##
+      basicauth/loki-tenant:
+        client_auth:
+          username: loki_tenant_demo
+          password: loki-tenant-demo-password
+
     exporters:
       otlp:
         endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
         tls:
           insecure: true
-      
+      otlphttp/ops-loki: ##
+        endpoint: http://loki-gateway.grafana-loki.svc.cluster.local:80/otlp
+        tls:
+          insecure: true
+        headers:
+          "X-Scope-OrgID": "loki-tenant-ociops"
+        auth: ##
+          authenticator: basicauth/loki-tenant
+
       # Debug exporter - can remove in production
       debug:
         verbosity: detailed    
 
     service:
+      extensions: [basicauth/loki-tenant]
       pipelines:
         logs:
           receivers: [filelog/std]
           processors: [batch, attributes, k8sattributes]
-          exporters: [otlp]
+          exporters: [otlp, otlphttp/ops-loki]
           #exporters: [otlp, debug]
   volumes:
     - name: varlog

--- a/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
@@ -819,8 +819,9 @@ spec:
 
     extensions: ##
       basicauth/mimir-tenant:
-        htpasswd:
-          file: /etc/otel/htpasswd/.htpasswd ## volume mount
+        client_auth:
+          username: cluster-forge-mimir-test-user
+          password: cluster-forge-mimir-test-pass
 
     exporters:
       # Configure your actual backend exporters here
@@ -848,33 +849,33 @@ spec:
           processors: [memory_limiter, batch]
           exporters: [otlp, otlphttp/ops-mimir]
           #exporters: [otlp, debug]
-  volumeMounts:
-    - name: htpasswd-volume
-      mountPath: /etc/otel/htpasswd
-      readOnly: true
-
-  volumes:
-    - name: htpasswd-volume
-      secret:
-        secretName: mimir-tenant-creds
-        items:
-          - key: .htpasswd
-            path: .htpasswd
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: mimir-tenant-creds-from-fake
-  namespace: otel-lgtm-stack
-spec:
-  refreshInterval: "30m"
-  secretStoreRef:
-    name: fake-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: mimir-tenant-creds
-  data:
-    - secretKey: .htpasswd
-      remoteRef:
-        key: .htpasswd
-        version: v1
+          #  volumeMounts:
+          #    - name: htpasswd-volume
+          #      mountPath: /etc/otel/htpasswd
+          #      readOnly: true
+          #
+          #  volumes:
+          #    - name: htpasswd-volume
+          #      secret:
+          #        secretName: mimir-tenant-creds
+          #        items:
+          #          - key: .htpasswd
+          #            path: .htpasswd
+          #---
+          #apiVersion: external-secrets.io/v1beta1
+          #kind: ExternalSecret
+          #metadata:
+          #  name: mimir-tenant-creds-from-fake
+          #  namespace: otel-lgtm-stack
+          #spec:
+          #  refreshInterval: "30m"
+          #  secretStoreRef:
+          #    name: fake-secret-store
+          #    kind: ClusterSecretStore
+          #  target:
+          #    name: mimir-tenant-creds
+          #  data:
+          #    - secretKey: .htpasswd
+          #      remoteRef:
+          #        key: .htpasswd
+          #        version: v1

--- a/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
@@ -812,20 +812,64 @@ spec:
         limit_percentage: 80
         spike_limit_percentage: 25
 
+    extensions: ##
+      basicauth/mimir-tenant:
+        htpasswd:
+          file: /etc/otel/htpasswd/.htpasswd ## volume mount
+
     exporters:
       # Configure your actual backend exporters here
       otlp:
         endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
         tls:
           insecure: true
+      otlphttp/ops-mimir: ##
+        endpoint: http://mimir-gateway.grafana-mimir.svc.cluster.local/otlp ##
+        tls:
+          insecure: true
+        headers:
+          "X-Scope-OrgID": "mimir-tenant-ociops" ##
+        auth: ##
+          authenticator: basicauth/mimir-tenant ##
       
       debug:
         verbosity: detailed
     
     service:
+      extensions: [basicauth/mimir-tenant] ##
       pipelines:
         metrics:
           receivers: [prometheus]
           processors: [memory_limiter, batch]
           exporters: [otlp]
           #exporters: [otlp, debug]
+  volumeMounts:
+    - name: htpasswd-volume
+      mountPath: /etc/otel/htpasswd
+      readOnly: true
+
+  volumes:
+    - name: htpasswd-volume
+      secret:
+        secretName: mimir-tenant-creds
+        items:
+          - key: .htpasswd
+            path: .htpasswd
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mimir-tenant-creds-from-fake
+  namespace: otel-lgtm-stack
+spec:
+  refreshInterval: "30m"
+  secretStoreRef:
+    name: fake-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: mimir-tenant-creds
+  data:
+    - secretKey: .htpasswd
+      remoteRef:
+        key: .htpasswd
+        version: v1


### PR DESCRIPTION
This PR updates otel-collector-metrics/logs of lgtm as prejobs for preparing inter-cluster data shipping over headscale.
After merging, otel-collectors send telemetries not only to lgtm stack, but also to monitoring backends like loki and mimir.

Highlights:
at input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
- New otlphttp endpoint pointing to monitoring backend added at exporters block for both of metrics and logs collectors
- BasicAuth extension added for authentication at loki/mimir-gateway
- Header and label of cluster_name added: `The value of header and label should be updated when it is applied`

at input/grafana/grafana-values.yaml
- Change the values of placeholders

at input/grafana-mimir/grafana-mimir-values.yaml
- Fix existingSecret and add an external-secret