### PR TITLE
Upgrade grafana helm version

### DIFF
--- a/input/config.yaml
+++ b/input/config.yaml
@@ -99,7 +99,7 @@
   secrets: false
   name: grafana
   namespace: "grafana"
-  helm-version: "8.4.6"
+  helm-version: "8.12.0"
   syncwave: 1
 # - helm-chart-name: "prometheus-opencost-exporter"
 #   helm-name: opencost


### PR DESCRIPTION
This PR upgrades the version of Grafana Helm from "8.4.6(grafana version: 11.1.4)" to "8.12.0(grafana version: 11.6.0)".

The new version of Grafana was tested on a kind cluster