### PR TITLE
add attributes process to otel-collector-metric

### DIFF
--- a/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
@@ -846,5 +846,5 @@ spec:
       pipelines:
         metrics:
           receivers: [prometheus]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, batch, attributes]
           exporters: [otlp, otlphttp/ops-mimir]


### PR DESCRIPTION
This PR adds "attributes process" adding "k8s_cluster_name"  label to all metrics.

Tested in ociops cluster.