### PR TITLE
stop using release type as name for folder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,16 +66,14 @@ jobs:
       - name: Create release package directory
         run: |
           # Create the desired top-level directory that will appear when unzipped
-          PACKAGE_DIR="clusterforge"
-          mkdir -p stacks/${PACKAGE_DIR}
+          mkdir -p stacks/clusterforge
           
           # Move the stack directory and ansible directory into the package directory
-          mv stacks/${{ github.event.inputs.version }}-${{ matrix.release.type }}/* stacks/${PACKAGE_DIR}/
+          mv stacks/${{ github.event.inputs.version }}-${{ matrix.release.type }}/* stacks/clusterforge/
 
       - name: Create tarball
         run: |
-          PACKAGE_DIR="clusterforge"
-          tar -C stacks/ -zcvf stacks/release-${{ matrix.release.type }}-${{ github.event.inputs.version }}.tar.gz ${PACKAGE_DIR}
+          tar -C stacks/ -zcvf stacks/release-${{ matrix.release.type }}-${{ github.event.inputs.version }}.tar.gz clusterforge
 
       - name: Create release
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Create release package directory
         run: |
           # Create the desired top-level directory that will appear when unzipped
-          PACKAGE_DIR="${{ matrix.release.type }}"
+          PACKAGE_DIR="clusterforge"
           mkdir -p stacks/${PACKAGE_DIR}
           
           # Move the stack directory and ansible directory into the package directory
@@ -74,7 +74,7 @@ jobs:
 
       - name: Create tarball
         run: |
-          PACKAGE_DIR="${{ matrix.release.type }}"
+          PACKAGE_DIR="clusterforge"
           tar -C stacks/ -zcvf stacks/release-${{ matrix.release.type }}-${{ github.event.inputs.version }}.tar.gz ${PACKAGE_DIR}
 
       - name: Create release


### PR DESCRIPTION
renaming to 'clusterforge'. Makes it way easier for clusterbloom