### PR TITLE
Add external-secrets calling secrets from 1password

### DIFF
--- a/input/1password-cluster-secret-store/manifests/ExternalSecret_grafana-loki.yaml
+++ b/input/1password-cluster-secret-store/manifests/ExternalSecret_grafana-loki.yaml
@@ -1,0 +1,34 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-loki-creds 
+  namespace: cf-es-backend
+spec:
+  data:
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: loki_tenant_name_oci1 
+    secretKey: loki_tenant_name_oci1
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: loki_tenant_name_oci2
+    secretKey: loki_tenant_name_oci2
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: loki_tenant_name_ocisilogen
+    secretKey: loki_tenant_name_ocisilogen
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: loki_tenant_name_ociops
+    secretKey: loki_tenant_name_ociops
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: loki_tenant_password_ociclusters
+    secretKey: loki_tenant_password_ociclusters 
+  refreshInterval: "0" 
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepass-oci
+  target:
+    creationPolicy: Owner
+    name: grafana-loki-creds 

--- a/input/1password-cluster-secret-store/manifests/ExternalSecret_grafana-mimir.yaml
+++ b/input/1password-cluster-secret-store/manifests/ExternalSecret_grafana-mimir.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-mimir-creds 
+  namespace: cf-es-backend
+spec:
+  data:
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: .htpasswd
+    secretKey: .htpasswd
+  refreshInterval: "0" 
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepass-oci
+  target:
+    creationPolicy: Owner
+    name: grafana-mimir-creds 

--- a/input/1password-cluster-secret-store/manifests/ExternalSecret_grafana.yaml
+++ b/input/1password-cluster-secret-store/manifests/ExternalSecret_grafana.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-creds 
+  namespace: cf-es-backend
+spec:
+  data:
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: grafana-admin-id
+    secretKey: grafana-admin-id
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: grafana-admin-pw
+    secretKey: grafana-admin-pw
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: alertmanager_contact_point_url 
+    secretKey: alertmanager_contact_point_url 
+  refreshInterval: "0" 
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepass-oci
+  target:
+    creationPolicy: Owner
+    name: grafana-creds 


### PR DESCRIPTION
This PR add three external-secrets for fetching secrets from 1password for monitoring tools in ociops.

After this PR, follow-up job will be updating monitoring tool side external-secrets to fetch from the secrets in cf-es-backend, not from "fake-cluster-secret-store"