### PR TITLE
Change the connect host url of the onepass-oci

### DIFF
--- a/input/1password-cluster-secret-store/manifests/ClusterSecretStore_onepass-oci.yaml
+++ b/input/1password-cluster-secret-store/manifests/ClusterSecretStore_onepass-oci.yaml
@@ -11,6 +11,6 @@ spec:
             key: token
             name: onepass-connect-access-token-ociops
             namespace: external-secrets
-      connectHost: http://central-onepass-connect-ociops.external-secrets.svc.cluster.local:8080
+      connectHost: http://central-onepass-proxy.headscale.svc.cluster.local:8080
       vaults:
         oci: 1


### PR DESCRIPTION
This PR changes the value of connectHost of onepass-oci.

Before: http://central-onepass-connect-ociops.external-secrets.svc.cluster.local:8080
After: http://central-onepass-proxy.headscale.svc.cluster.local:8080