### PR TITLE
Add the manifests of loki and mimir

### DIFF
--- a/input/config.yaml
+++ b/input/config.yaml
@@ -149,24 +149,28 @@
   manifestpath:
   - minio-tenant/manifests/k8s-secret
   skip-namespace: true
-- helm-chart-name: "loki"
-  helm-name: loki
-  helm-url: "https://grafana.github.io/helm-charts"
-  values: grafana-loki-values.yaml
-  secrets: false
-  name: grafana-loki
+- name: grafana-loki
   namespace: "grafana-loki"
-  helm-version: "6.15.0"
   syncwave: 1
-- helm-chart-name: "mimir-distributed"
-  helm-name: mimir
-  helm-url: "https://grafana.github.io/helm-charts"
-  values: grafana-mimir-values.yaml
-  secrets: false
-  name: grafana-mimir
+  manifestpath:
+  - grafana-loki/manifests
+#  helm-chart-name: "loki"
+#  helm-name: loki
+#  helm-url: "https://grafana.github.io/helm-charts"
+#  values: grafana-loki-values.yaml
+#  secrets: false
+#  helm-version: "6.15.0"
+- name: grafana-mimir
   namespace: "grafana-mimir"
-  helm-version: "5.2.1"
   syncwave: 1
+  manifestpath:
+  - grafana-mimir/manifests
+#  helm-chart-name: "mimir-distributed"
+#  helm-name: mimir
+#  helm-url: "https://grafana.github.io/helm-charts"
+#  values: grafana-mimir-values.yaml
+#  secrets: false
+#  helm-version: "5.2.1"
 - helm-chart-name: "redis"
   helm-name: redis
   helm-url: "https://charts.bitnami.com/bitnami"

--- a/input/grafana-loki/manifests/ClusterRoleBinding_loki-clusterrolebinding.yaml
+++ b/input/grafana-loki/manifests/ClusterRoleBinding_loki-clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: loki
+    namespace: grafana-loki

--- a/input/grafana-loki/manifests/ClusterRole_loki-clusterrole.yaml
+++ b/input/grafana-loki/manifests/ClusterRole_loki-clusterrole.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list

--- a/input/grafana-loki/manifests/ConfigMap_loki-gateway.yaml
+++ b/input/grafana-loki/manifests/ConfigMap_loki-gateway.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: v1
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      client_max_body_size  4M;
+
+      proxy_read_timeout    600; ## 10 minutes
+      proxy_send_timeout    600;
+      proxy_connect_timeout 600;
+
+      proxy_http_version    1.1;
+
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+            '"$request" $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+
+      sendfile     on;
+      tcp_nopush   on;
+      resolver rke2-coredns-rke2-coredns.kube-system.svc.cluster.local;
+      proxy_set_header X-Scope-OrgID $remote_user;
+
+      server {
+        listen             8080;
+        listen             [::]:8080;
+
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+
+        location = /api/prom/push {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1/push {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /distributor/ring {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /otlp/v1/logs {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /flush {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location ^~ /ingester/ {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /ingester {
+          internal;        # to suppress 301
+        }
+
+        location = /ring {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /memberlist {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /ruler/ring {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /api/prom/rules {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location ^~ /api/prom/rules/ {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1/rules {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location ^~ /loki/api/v1/rules/ {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /prometheus/api/v1/alerts {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /prometheus/api/v1/rules {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /compactor/ring {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1/delete {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1/cache/generation_numbers {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /indexgateway/ring {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /scheduler/ring {
+          proxy_pass       http://loki-backend.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /config {
+          proxy_pass       http://loki-write.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+
+
+        location = /api/prom/tail {
+          proxy_pass       http://loki-read.grafana-loki.svc.cluster.local:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+        location = /loki/api/v1/tail {
+          proxy_pass       http://loki-read.grafana-loki.svc.cluster.local:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+        location ^~ /api/prom/ {
+          proxy_pass       http://loki-read.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /api/prom {
+          internal;        # to suppress 301
+        }
+        location ^~ /loki/api/v1/ {
+          proxy_pass       http://loki-read.grafana-loki.svc.cluster.local:3100$request_uri;
+        }
+        location = /loki/api/v1 {
+          internal;        # to suppress 301
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-gateway
+  namespace: grafana-loki

--- a/input/grafana-loki/manifests/ConfigMap_loki-runtime.yaml
+++ b/input/grafana-loki/manifests/ConfigMap_loki-runtime.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+data:
+  runtime-config.yaml: |
+    {}
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-runtime
+  namespace: grafana-loki

--- a/input/grafana-loki/manifests/ConfigMap_loki.yaml
+++ b/input/grafana-loki/manifests/ConfigMap_loki.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: v1
+data:
+  config.yaml: |
+    auth_enabled: true
+    bloom_build:
+      builder:
+        planner_address: loki-backend-headless.grafana-loki.svc.cluster.local:9095
+      enabled: false
+    bloom_gateway:
+      client:
+        addresses: dnssrvnoa+_grpc._tcp.loki-backend-headless.grafana-loki.svc.cluster.local
+      enabled: false
+    chunk_store_config:
+      chunk_cache_config:
+        background:
+          writeback_buffer: 500000
+          writeback_goroutines: 1
+          writeback_size_limit: 500MB
+        default_validity: 0s
+        memcached:
+          batch_size: 4
+          parallelism: 5
+        memcached_client:
+          addresses: dnssrvnoa+_memcached-client._tcp.loki-chunks-cache.grafana-loki.svc
+          consistent_hash: true
+          max_idle_conns: 72
+          timeout: 2000ms
+    common:
+      compactor_address: 'http://loki-backend:3100'
+      path_prefix: /var/loki
+      replication_factor: 1
+      ring:
+        heartbeat_timeout: 10m
+        kvstore:
+          store: memberlist
+      storage:
+        s3:
+          bucketnames: chunks
+          insecure: false
+          s3forcepathstyle: false
+    compactor:
+      compaction_interval: 10m
+      delete_request_store: s3
+      retention_delete_delay: 2h
+      retention_delete_worker_count: 150
+      retention_enabled: true
+      working_directory: /var/loki/data/retention
+    frontend:
+      scheduler_address: ""
+      tail_proxy_url: ""
+    frontend_worker:
+      scheduler_address: ""
+    index_gateway:
+      mode: simple
+    ingester:
+      autoforget_unhealthy: true
+      chunk_encoding: snappy
+    limits_config:
+      index_gateway_shard_size: 1
+      ingestion_burst_size_mb: 30
+      ingestion_rate_mb: 20
+      max_cache_freshness_per_query: 10m
+      query_timeout: 120s
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+      retention_period: 168h
+      split_queries_by_interval: 15m
+      volume_enabled: true
+    memberlist:
+      join_members:
+      - loki-memberlist
+    pattern_ingester:
+      enabled: false
+    query_range:
+      align_queries_with_step: true
+      cache_results: true
+      results_cache:
+        cache:
+          background:
+            writeback_buffer: 500000
+            writeback_goroutines: 1
+            writeback_size_limit: 500MB
+          default_validity: 12h
+          memcached_client:
+            addresses: dnssrvnoa+_memcached-client._tcp.loki-results-cache.grafana-loki.svc
+            consistent_hash: true
+            timeout: 500ms
+            update_interval: 1m
+    ruler:
+      storage:
+        s3:
+          bucketnames: ruler
+          insecure: false
+          s3forcepathstyle: false
+        type: s3
+    runtime_config:
+      file: /etc/loki/runtime-config/runtime-config.yaml
+    schema_config:
+      configs:
+      - from: "2024-01-01"
+        index:
+          period: 24h
+          prefix: index_
+        object_store: s3
+        schema: v13
+        store: tsdb
+    server:
+      grpc_listen_port: 9095
+      grpc_server_max_recv_msg_size: 104857600
+      grpc_server_max_send_msg_size: 104857600
+      http_listen_port: 3100
+      http_server_read_timeout: 120s
+      http_server_write_timeout: 120s
+    storage_config:
+      aws:
+        access_key_id: ${API_ACCESS_KEY}
+        bucketnames: cluster-forge-loki
+        endpoint: http://minio.minio-tenant-default.svc.cluster.local:80
+        http_config:
+          insecure_skip_verify: true
+        insecure: true
+        s3forcepathstyle: true
+        secret_access_key: ${API_SECRET_KEY}
+      bloom_shipper:
+        working_directory: /var/loki/data/bloomshipper
+      boltdb_shipper:
+        index_gateway_client:
+          server_address: dns+loki-backend-headless.grafana-loki.svc.cluster.local:9095
+      hedging:
+        at: 250ms
+        max_per_second: 20
+        up_to: 3
+      tsdb_shipper:
+        active_index_directory: /var/loki/data/tsdb-index
+        cache_location: /var/loki/data/tsdb-cache
+        index_gateway_client:
+          server_address: dns+loki-backend-headless.grafana-loki.svc.cluster.local:9095
+    tracing:
+      enabled: false
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki
+  namespace: grafana-loki

--- a/input/grafana-loki/manifests/Deployment_loki-gateway.yaml
+++ b/input/grafana-loki/manifests/Deployment_loki-gateway.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-gateway
+  namespace: grafana-loki
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: gateway
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 44109e4cd34c12081953e63c74996614b6056efaeede62bfa960d3c20cd34c81
+      labels:
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/name: loki
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: gateway
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - image: docker.io/nginxinc/nginx-unprivileged:1.27-alpine
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http-metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/nginx
+              name: config
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /docker-entrypoint.d
+              name: docker-entrypoint-d-override
+      enableServiceLinks: true
+      securityContext:
+        fsGroup: 101
+        runAsGroup: 101
+        runAsNonRoot: true
+        runAsUser: 101
+      serviceAccountName: loki
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            name: loki-gateway
+          name: config
+        - emptyDir: {}
+          name: tmp
+        - emptyDir: {}
+          name: docker-entrypoint-d-override

--- a/input/grafana-loki/manifests/Deployment_loki-read.yaml
+++ b/input/grafana-loki/manifests/Deployment_loki-read.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: read
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 3.1.1
+  name: loki-read
+  namespace: grafana-loki
+spec:
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: read
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: dbb440eae4bc22dc6ba70cea6930e5ba6eb2321b301104648789f9ae5b15be0a
+      labels:
+        app.kubernetes.io/component: read
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: read
+              topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=read
+            - -legacy-read-mode=false
+            - -common.compactor-grpc-address=loki-backend.grafana-loki.svc.cluster.local:9095
+            - -config.expand-env=true
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: loki-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: loki-minio-creds
+            - name: TENANT_NAME_OCI1
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_oci1
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCI2
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_oci2
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCISILOGEN
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ocisilogen
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCIOPS
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ociops
+                  name: loki-tenant-creds
+            - name: TENANT_PW
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_password_ociclusters
+                  name: loki-tenant-creds
+          image: docker.io/grafana/loki:3.1.1
+          imagePullPolicy: IfNotPresent
+          name: loki
+          ports:
+            - containerPort: 3100
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: http-memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/loki/config
+              name: config
+            - mountPath: /etc/loki/runtime-config
+              name: runtime-config
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/loki
+              name: data
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      serviceAccountName: loki
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: tmp
+        - emptyDir: {}
+          name: data
+        - configMap:
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: loki
+          name: config
+        - configMap:
+            name: loki-runtime
+          name: runtime-config

--- a/input/grafana-loki/manifests/ExternalSecret_loki-minio-creds.yaml
+++ b/input/grafana-loki/manifests/ExternalSecret_loki-minio-creds.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: loki-minio-creds
+  namespace: grafana-loki
+spec:
+  data:
+    - remoteRef:
+        key: default-user
+        property: API_ACCESS_KEY
+      secretKey: API_ACCESS_KEY
+    - remoteRef:
+        key: default-user
+        property: API_SECRET_KEY
+      secretKey: API_SECRET_KEY
+  refreshInterval: 30m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: minio-secret-store
+  target:
+    name: loki-minio-creds

--- a/input/grafana-loki/manifests/ExternalSecret_loki-tenant-creds.yaml
+++ b/input/grafana-loki/manifests/ExternalSecret_loki-tenant-creds.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: loki-tenant-creds
+  namespace: grafana-loki
+spec:
+  data:
+    - remoteRef:
+        key: grafana-loki-creds
+        property: loki_tenant_name_oci1
+      secretKey: loki_tenant_name_oci1
+    - remoteRef:
+        key: grafana-loki-creds
+        property: loki_tenant_name_oci2
+      secretKey: loki_tenant_name_oci2
+    - remoteRef:
+        key: grafana-loki-creds
+        property: loki_tenant_name_ocisilogen
+      secretKey: loki_tenant_name_ocisilogen
+    - remoteRef:
+        key: grafana-loki-creds
+        property: loki_tenant_name_ociops
+      secretKey: loki_tenant_name_ociops
+    - remoteRef:
+        key: grafana-loki-creds
+        property: loki_tenant_password_ociclusters
+      secretKey: loki_tenant_password_ociclusters
+  refreshInterval: "0"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-secret-store
+  target:
+    name: loki-tenant-creds

--- a/input/grafana-loki/manifests/Namespace_grafana-loki.yaml
+++ b/input/grafana-loki/manifests/Namespace_grafana-loki.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana-loki

--- a/input/grafana-loki/manifests/PodDisruptionBudget_loki-backend.yaml
+++ b/input/grafana-loki/manifests/PodDisruptionBudget_loki-backend.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-backend
+  namespace: grafana-loki
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: backend
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki

--- a/input/grafana-loki/manifests/PodDisruptionBudget_loki-memcached-chunks-cache.yaml
+++ b/input/grafana-loki/manifests/PodDisruptionBudget_loki-memcached-chunks-cache.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: memcached-chunks-cache
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  name: loki-memcached-chunks-cache
+  namespace: grafana-loki
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: memcached-chunks-cache
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki

--- a/input/grafana-loki/manifests/PodDisruptionBudget_loki-memcached-results-cache.yaml
+++ b/input/grafana-loki/manifests/PodDisruptionBudget_loki-memcached-results-cache.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: memcached-results-cache
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  name: loki-memcached-results-cache
+  namespace: grafana-loki
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: memcached-results-cache
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki

--- a/input/grafana-loki/manifests/PodDisruptionBudget_loki-read.yaml
+++ b/input/grafana-loki/manifests/PodDisruptionBudget_loki-read.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: read
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-read
+  namespace: grafana-loki
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: read
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki

--- a/input/grafana-loki/manifests/PodDisruptionBudget_loki-write.yaml
+++ b/input/grafana-loki/manifests/PodDisruptionBudget_loki-write.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-write
+  namespace: grafana-loki
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: write
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki

--- a/input/grafana-loki/manifests/ServiceAccount_loki.yaml
+++ b/input/grafana-loki/manifests/ServiceAccount_loki.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki
+  namespace: grafana-loki

--- a/input/grafana-loki/manifests/Service_loki-backend-headless.yaml
+++ b/input/grafana-loki/manifests/Service_loki-backend-headless.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    prometheus.io/service-monitor: "false"
+    variant: headless
+  name: loki-backend-headless
+  namespace: grafana-loki
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-backend.yaml
+++ b/input/grafana-loki/manifests/Service_loki-backend.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-backend
+  namespace: grafana-loki
+spec:
+  ports:
+    - name: http-metrics
+      port: 3100
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-chunks-cache.yaml
+++ b/input/grafana-loki/manifests/Service_loki-chunks-cache.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: memcached-chunks-cache
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-chunks-cache
+  namespace: grafana-loki
+spec:
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+  selector:
+    app.kubernetes.io/component: memcached-chunks-cache
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-gateway.yaml
+++ b/input/grafana-loki/manifests/Service_loki-gateway.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-gateway
+  namespace: grafana-loki
+spec:
+  ports:
+    - name: http-metrics
+      port: 80
+      protocol: TCP
+      targetPort: http-metrics
+  selector:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP
+  clusterIP: 10.43.184.169 ## Static IP  

--- a/input/grafana-loki/manifests/Service_loki-memberlist.yaml
+++ b/input/grafana-loki/manifests/Service_loki-memberlist.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-memberlist
+  namespace: grafana-loki
+spec:
+  clusterIP: None
+  ports:
+    - name: tcp
+      port: 7946
+      protocol: TCP
+      targetPort: http-memberlist
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: memberlist
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-query-scheduler-discovery.yaml
+++ b/input/grafana-loki/manifests/Service_loki-query-scheduler-discovery.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    prometheus.io/service-monitor: "false"
+  name: loki-query-scheduler-discovery
+  namespace: grafana-loki
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-read-headless.yaml
+++ b/input/grafana-loki/manifests/Service_loki-read-headless.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: read
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    prometheus.io/service-monitor: "false"
+    variant: headless
+  name: loki-read-headless
+  namespace: grafana-loki
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      protocol: TCP
+      targetPort: http-metrics
+    - appProtocol: tcp
+      name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: read
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-read.yaml
+++ b/input/grafana-loki/manifests/Service_loki-read.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: read
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-read
+  namespace: grafana-loki
+spec:
+  ports:
+    - name: http-metrics
+      port: 3100
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: read
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-results-cache.yaml
+++ b/input/grafana-loki/manifests/Service_loki-results-cache.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: memcached-results-cache
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-results-cache
+  namespace: grafana-loki
+spec:
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+  selector:
+    app.kubernetes.io/component: memcached-results-cache
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-write-headless.yaml
+++ b/input/grafana-loki/manifests/Service_loki-write-headless.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    prometheus.io/service-monitor: "false"
+    variant: headless
+  name: loki-write-headless
+  namespace: grafana-loki
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      protocol: TCP
+      targetPort: http-metrics
+    - appProtocol: tcp
+      name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/Service_loki-write.yaml
+++ b/input/grafana-loki/manifests/Service_loki-write.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+  name: loki-write
+  namespace: grafana-loki
+spec:
+  ports:
+    - name: http-metrics
+      port: 3100
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  type: ClusterIP

--- a/input/grafana-loki/manifests/StatefulSet_loki-backend.yaml
+++ b/input/grafana-loki/manifests/StatefulSet_loki-backend.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 3.1.1
+  name: loki-backend
+  namespace: grafana-loki
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: backend
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+  serviceName: loki-backend-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config: dbb440eae4bc22dc6ba70cea6930e5ba6eb2321b301104648789f9ae5b15be0a
+      labels:
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: backend
+              topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
+      containers:
+        - env:
+            - name: METHOD
+              value: WATCH
+            - name: LABEL
+              value: loki_rule
+            - name: FOLDER
+              value: /rules
+            - name: RESOURCE
+              value: both
+            - name: WATCH_SERVER_TIMEOUT
+              value: "60"
+            - name: WATCH_CLIENT_TIMEOUT
+              value: "60"
+            - name: LOG_LEVEL
+              value: debug
+          image: kiwigrid/k8s-sidecar:1.27.5
+          imagePullPolicy: IfNotPresent
+          name: loki-sc-rules
+          volumeMounts:
+            - mountPath: /rules
+              name: sc-rules-volume
+        - args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=backend
+            - -legacy-read-mode=false
+            - -config.expand-env=true
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: loki-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: loki-minio-creds
+            - name: TENANT_NAME_OCI1
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_oci1
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCI2
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_oci2
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCISILOGEN
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ocisilogen
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCIOPS
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ociops
+                  name: loki-tenant-creds
+            - name: TENANT_PW
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_password_ociclusters
+                  name: loki-tenant-creds
+          image: docker.io/grafana/loki:3.1.1
+          imagePullPolicy: IfNotPresent
+          name: loki
+          ports:
+            - containerPort: 3100
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: http-memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/loki/config
+              name: config
+            - mountPath: /etc/loki/runtime-config
+              name: runtime-config
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/loki
+              name: data
+            - mountPath: /rules
+              name: sc-rules-volume
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      serviceAccountName: loki
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - emptyDir: {}
+          name: tmp
+        - configMap:
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: loki
+          name: config
+        - configMap:
+            name: loki-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: sc-rules-volume
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        storageClassName: longhorn-default

--- a/input/grafana-loki/manifests/StatefulSet_loki-chunks-cache.yaml
+++ b/input/grafana-loki/manifests/StatefulSet_loki-chunks-cache.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: memcached-chunks-cache
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+    name: memcached-chunks-cache
+  name: loki-chunks-cache
+  namespace: grafana-loki
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: memcached-chunks-cache
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+      name: memcached-chunks-cache
+  serviceName: loki-chunks-cache
+  template:
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: memcached-chunks-cache
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/name: loki
+        name: memcached-chunks-cache
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -m 8192
+            - --extended=modern,track_sizes
+            - -I 5m
+            - -c 16384
+            - -v
+            - -u 11211
+          env: null
+          envFrom: null
+          image: memcached:1.6.23-alpine
+          imagePullPolicy: IfNotPresent
+          name: memcached
+          ports:
+            - containerPort: 11211
+              name: client
+          resources:
+            limits:
+              memory: 9830Mi
+            requests:
+              cpu: 500m
+              memory: 9830Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+        - args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: prom/memcached-exporter:v0.14.2
+          imagePullPolicy: IfNotPresent
+          name: exporter
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 11211
+        runAsGroup: 11211
+        runAsNonRoot: true
+        runAsUser: 11211
+      serviceAccountName: loki
+      terminationGracePeriodSeconds: 60
+      tolerations: []
+      topologySpreadConstraints: []
+  updateStrategy:
+    type: RollingUpdate

--- a/input/grafana-loki/manifests/StatefulSet_loki-results-cache.yaml
+++ b/input/grafana-loki/manifests/StatefulSet_loki-results-cache.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: memcached-results-cache
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/version: 3.1.1
+    name: memcached-results-cache
+  name: loki-results-cache
+  namespace: grafana-loki
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: memcached-results-cache
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+      name: memcached-results-cache
+  serviceName: loki-results-cache
+  template:
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: memcached-results-cache
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/name: loki
+        name: memcached-results-cache
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -m 1024
+            - --extended=modern,track_sizes
+            - -I 5m
+            - -c 16384
+            - -v
+            - -u 11211
+          env: null
+          envFrom: null
+          image: memcached:1.6.23-alpine
+          imagePullPolicy: IfNotPresent
+          name: memcached
+          ports:
+            - containerPort: 11211
+              name: client
+          resources:
+            limits:
+              memory: 1229Mi
+            requests:
+              cpu: 500m
+              memory: 1229Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+        - args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: prom/memcached-exporter:v0.14.2
+          imagePullPolicy: IfNotPresent
+          name: exporter
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 11211
+        runAsGroup: 11211
+        runAsNonRoot: true
+        runAsUser: 11211
+      serviceAccountName: loki
+      terminationGracePeriodSeconds: 60
+      tolerations: []
+      topologySpreadConstraints: []
+  updateStrategy:
+    type: RollingUpdate

--- a/input/grafana-loki/manifests/StatefulSet_loki-write.yaml
+++ b/input/grafana-loki/manifests/StatefulSet_loki-write.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 3.1.1
+  name: loki-write
+  namespace: grafana-loki
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: write
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+  serviceName: loki-write-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config: dbb440eae4bc22dc6ba70cea6930e5ba6eb2321b301104648789f9ae5b15be0a
+      labels:
+        app.kubernetes.io/component: write
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: write
+              topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=write
+            - -config.expand-env=true
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: loki-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: loki-minio-creds
+            - name: TENANT_NAME_OCI1
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_oci1
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCI2
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_oci2
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCISILOGEN
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ocisilogen
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCIOPS
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ociops
+                  name: loki-tenant-creds
+            - name: TENANT_PW
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_password_ociclusters
+                  name: loki-tenant-creds
+          image: docker.io/grafana/loki:3.1.1
+          imagePullPolicy: IfNotPresent
+          name: loki
+          ports:
+            - containerPort: 3100
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: http-memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/loki/config
+              name: config
+            - mountPath: /etc/loki/runtime-config
+              name: runtime-config
+            - mountPath: /var/loki
+              name: data
+      enableServiceLinks: true
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      serviceAccountName: loki
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - configMap:
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: loki
+          name: config
+        - configMap:
+            name: loki-runtime
+          name: runtime-config
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        storageClassName: longhorn-default

--- a/input/grafana-mimir/manifests/ConfigMap_mimir-config.yaml
+++ b/input/grafana-mimir/manifests/ConfigMap_mimir-config.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: v1
+data:
+  mimir.yaml: |
+    activity_tracker:
+      filepath: /active-query-tracker/activity.log
+    alertmanager:
+      data_dir: /data
+      enable_api: true
+      external_url: /alertmanager
+      fallback_config_file: /configs/alertmanager_fallback_config.yaml
+    alertmanager_storage:
+      s3:
+        bucket_name: cluster-forge-mimir
+        insecure: true
+    blocks_storage:
+      backend: s3
+      bucket_store:
+        chunks_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+mimir-chunks-cache.grafana-mimir.svc:11211
+            max_idle_connections: 150
+            max_item_size: 1048576
+            timeout: 450ms
+        index_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+mimir-index-cache.grafana-mimir.svc:11211
+            max_idle_connections: 150
+            max_item_size: 5242880
+            timeout: 450ms
+        metadata_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+mimir-metadata-cache.grafana-mimir.svc:11211
+            max_idle_connections: 150
+            max_item_size: 1048576
+        sync_dir: /data/tsdb-sync
+      s3:
+        bucket_name: cluster-forge-mimir
+        insecure: true
+      tsdb:
+        dir: /data/tsdb
+        head_compaction_interval: 15m
+        wal_replay_concurrency: 3
+    common:
+      storage:
+        backend: s3
+        s3:
+          access_key_id: ${API_ACCESS_KEY}
+          endpoint: minio.minio-tenant-default.svc.cluster.local:80
+          http:
+            insecure_skip_verify: true
+          insecure: true
+          secret_access_key: ${API_SECRET_KEY}
+    compactor:
+      compaction_interval: 30m
+      data_dir: /data
+      deletion_delay: 2h
+      first_level_compaction_wait_period: 25m
+      max_closing_blocks_concurrency: 2
+      max_opening_blocks_concurrency: 4
+      sharding_ring:
+        wait_stability_min_duration: 1m
+      symbols_flushers_concurrency: 4
+    distributor:
+      max_recv_msg_size: 268435456
+    frontend:
+      cache_results: true
+      parallelize_shardable_queries: true
+      query_sharding_target_series_per_shard: 2500
+      results_cache:
+        backend: memcached
+        memcached:
+          addresses: dns+mimir-results-cache.grafana-mimir.svc:11211
+          max_item_size: 5242880
+          timeout: 500ms
+      scheduler_address: mimir-query-scheduler-headless.grafana-mimir.svc:9095
+    frontend_worker:
+      grpc_client_config:
+        max_send_msg_size: 419430400
+      scheduler_address: mimir-query-scheduler-headless.grafana-mimir.svc:9095
+    ingester:
+      ring:
+        final_sleep: 0s
+        num_tokens: 512
+        tokens_file_path: /data/tokens
+        unregister_on_shutdown: false
+        zone_awareness_enabled: true
+    ingester_client:
+      grpc_client_config:
+        max_recv_msg_size: 268435456
+        max_send_msg_size: 268435456
+    limits:
+      max_cache_freshness: 10m
+      max_global_series_per_user: 1000000
+      max_label_names_per_series: 150
+      max_query_parallelism: 240
+      max_total_query_length: 12000h
+    memberlist:
+      abort_if_cluster_join_fails: false
+      compression_enabled: false
+      join_members:
+      - dns+mimir-gossip-ring.grafana-mimir.svc.cluster.local.:7946
+    querier:
+      max_concurrent: 16
+    query_scheduler:
+      max_outstanding_requests_per_tenant: 800
+    ruler:
+      alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.mimir-alertmanager-headless.grafana-mimir.svc.cluster.local./alertmanager
+      enable_api: true
+      rule_path: /data
+    ruler_storage:
+      cache:
+        backend: memcached
+        memcached:
+          addresses: dns+mimir-metadata-cache.grafana-mimir.svc:11211
+          max_item_size: 1048576
+      s3:
+        bucket_name: cluster-forge-mimir
+        insecure: true
+    runtime_config:
+      file: /var/mimir/runtime.yaml
+    server:
+      grpc_server_max_connection_age: 2m
+      grpc_server_max_connection_age_grace: 5m
+      grpc_server_max_connection_idle: 1m
+      grpc_server_max_recv_msg_size: 268435456
+      grpc_server_max_send_msg_size: 268435456
+    store_gateway:
+      sharding_ring:
+        kvstore:
+          prefix: multi-zone/
+        tokens_file_path: /data/tokens
+        unregister_on_shutdown: false
+        wait_stability_min_duration: 1m
+        zone_awareness_enabled: true
+    usage_stats:
+      installation_mode: helm
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-config
+  namespace: grafana-mimir

--- a/input/grafana-mimir/manifests/ConfigMap_mimir-gateway-nginx.yaml
+++ b/input/grafana-mimir/manifests/ConfigMap_mimir-gateway-nginx.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: v1
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr error;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+            '"$request" $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+
+      sendfile     on;
+      tcp_nopush   on;
+      resolver rke2-coredns-rke2-coredns.kube-system.svc.cluster.local;
+
+      map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        "" "anonymous";
+      }
+
+      proxy_read_timeout 300;
+      server {
+        listen 8080;
+        listen [::]:8080;
+        auth_basic           "Mimir";
+        auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+
+        location = /ready {
+          return 200 'OK';
+          auth_basic off;
+        }
+
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+
+        location /distributor {
+          set $distributor mimir-distributor-headless.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+        location = /api/v1/push {
+          set $distributor mimir-distributor-headless.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+        location /otlp/v1/metrics {
+          set $distributor mimir-distributor-headless.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+
+        location /alertmanager {
+          set $alertmanager mimir-alertmanager-headless.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+        location = /multitenant_alertmanager/status {
+          set $alertmanager mimir-alertmanager-headless.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+        location = /api/v1/alerts {
+          set $alertmanager mimir-alertmanager-headless.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+
+        location /prometheus/config/v1/rules {
+          set $ruler mimir-ruler.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+        location /prometheus/api/v1/rules {
+          set $ruler mimir-ruler.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+
+        location /prometheus/api/v1/alerts {
+          set $ruler mimir-ruler.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+        location = /ruler/ring {
+          set $ruler mimir-ruler.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+
+        location /prometheus {
+          set $query_frontend mimir-query-frontend.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$query_frontend:8080$request_uri;
+        }
+
+        location = /api/v1/status/buildinfo {
+          set $query_frontend mimir-query-frontend.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$query_frontend:8080$request_uri;
+        }
+
+        location /api/v1/upload/block/ {
+          set $compactor mimir-compactor.grafana-mimir.svc.cluster.local.;
+          proxy_pass      http://$compactor:8080$request_uri;
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: gateway-nginx
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-gateway-nginx
+  namespace: grafana-mimir

--- a/input/grafana-mimir/manifests/ConfigMap_mimir-runtime.yaml
+++ b/input/grafana-mimir/manifests/ConfigMap_mimir-runtime.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+data:
+  runtime.yaml: |
+    {}
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-runtime
+  namespace: grafana-mimir

--- a/input/grafana-mimir/manifests/Deployment_mimir-distributor.yaml
+++ b/input/grafana-mimir/manifests/Deployment_mimir-distributor.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-distributor
+  namespace: grafana-mimir
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+      namespace: grafana-mimir
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -target=distributor
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+            - name: GOMAXPROCS
+              value: "8"
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: distributor
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: 1
+              memory: 760Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+              subPath: null
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 60
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: distributor
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: storage
+        - emptyDir: {}
+          name: active-queries

--- a/input/grafana-mimir/manifests/Deployment_mimir-gateway.yaml
+++ b/input/grafana-mimir/manifests/Deployment_mimir-gateway.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-gateway
+  namespace: grafana-mimir
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: gateway
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 6e1d3774dc9ed5675b3dcaf6fcf57cb373b1228996f5b98916fc18665b7fd02f
+      labels:
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+      namespace: grafana-mimir
+    spec:
+      affinity: {}
+      containers:
+        - args: null
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: docker.io/nginxinc/nginx-unprivileged:1.25-alpine
+          imagePullPolicy: IfNotPresent
+          name: nginx
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/nginx
+              name: nginx-config
+            - mountPath: /etc/nginx/secrets
+              name: auth
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /docker-entrypoint.d
+              name: docker-entrypoint-d-override
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: gateway
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - configMap:
+            name: mimir-gateway-nginx
+          name: nginx-config
+        - emptyDir: {}
+          name: docker-entrypoint-d-override
+        - name: auth
+          secret:
+            secretName: mimir-tenant-creds
+        - emptyDir: {}
+          name: tmp

--- a/input/grafana-mimir/manifests/Deployment_mimir-overrides-exporter.yaml
+++ b/input/grafana-mimir/manifests/Deployment_mimir-overrides-exporter.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-overrides-exporter
+  namespace: grafana-mimir
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: overrides-exporter
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: overrides-exporter
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+      namespace: grafana-mimir
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -target=overrides-exporter
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          name: overrides-exporter
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+              subPath: null
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 60
+      tolerations: []
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: storage
+        - emptyDir: {}
+          name: active-queries

--- a/input/grafana-mimir/manifests/Deployment_mimir-querier.yaml
+++ b/input/grafana-mimir/manifests/Deployment_mimir-querier.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-querier
+  namespace: grafana-mimir
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -target=querier
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+            - name: GOMAXPROCS
+              value: "5"
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: querier
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            limits:
+              memory: 3000Mi
+            requests:
+              cpu: 100m
+              memory: 2525Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+              subPath: null
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 180
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: querier
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: storage
+        - emptyDir: {}
+          name: active-queries

--- a/input/grafana-mimir/manifests/Deployment_mimir-query-frontend.yaml
+++ b/input/grafana-mimir/manifests/Deployment_mimir-query-frontend.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-query-frontend
+  namespace: grafana-mimir
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+      namespace: grafana-mimir
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -target=query-frontend
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: query-frontend
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            limits:
+              memory: 1000Mi
+            requests:
+              cpu: 200m
+              memory: 623Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 180
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: query-frontend
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: storage
+        - emptyDir: {}
+          name: active-queries

--- a/input/grafana-mimir/manifests/Deployment_mimir-query-scheduler.yaml
+++ b/input/grafana-mimir/manifests/Deployment_mimir-query-scheduler.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-query-scheduler
+  namespace: grafana-mimir
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-scheduler
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: query-scheduler
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -target=query-scheduler
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+            - -server.grpc.keepalive.max-connection-age=2562047h
+            - -server.grpc.keepalive.max-connection-age-grace=2562047h
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: query-scheduler
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 180
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: query-scheduler
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: storage
+        - emptyDir: {}
+          name: active-queries

--- a/input/grafana-mimir/manifests/Deployment_mimir-rollout-operator.yaml
+++ b/input/grafana-mimir/manifests/Deployment_mimir-rollout-operator.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-rollout-operator
+  namespace: grafana-mimir
+  labels:
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/version: v0.9.0
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: rollout-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: rollout-operator
+    spec:
+      containers:
+        - args:
+            - -kubernetes.namespace=grafana-mimir
+          image: grafana/rollout-operator:v0.9.0
+          imagePullPolicy: IfNotPresent
+          name: rollout-operator
+          ports:
+            - containerPort: 8001
+              name: http-metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: "1"
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir-rollout-operator

--- a/input/grafana-mimir/manifests/ExternalSecret_mimir-minio-creds.yaml
+++ b/input/grafana-mimir/manifests/ExternalSecret_mimir-minio-creds.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mimir-minio-creds
+  namespace: grafana-mimir
+spec:
+  data:
+    - remoteRef:
+        key: default-user
+        property: API_ACCESS_KEY
+      secretKey: API_ACCESS_KEY
+    - remoteRef:
+        key: default-user
+        property: API_SECRET_KEY
+      secretKey: API_SECRET_KEY
+  refreshInterval: 30m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: minio-secret-store
+  target:
+    name: mimir-minio-creds

--- a/input/grafana-mimir/manifests/ExternalSecret_mimir-tenant-creds.yaml
+++ b/input/grafana-mimir/manifests/ExternalSecret_mimir-tenant-creds.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mimir-tenant-creds
+  namespace: grafana-mimir
+spec:
+  data:
+    - remoteRef:
+        key: grafana-mimir-creds
+        property: .htpasswd
+      secretKey: .htpasswd
+  refreshInterval: "0"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-secret-store
+  target:
+    name: mimir-tenant-creds

--- a/input/grafana-mimir/manifests/Job_mimir-smoke-test.yaml
+++ b/input/grafana-mimir/manifests/Job_mimir-smoke-test.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: test
+  labels:
+    app.kubernetes.io/component: smoke-test
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-smoke-test
+  namespace: grafana-mimir
+spec:
+  backoffLimit: 5
+  completions: 1
+  parallelism: 1
+  selector: null
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: smoke-test
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+    spec:
+      containers:
+        - args:
+            - -tests.smoke-test
+            - -tests.write-endpoint=http://mimir-gateway.grafana-mimir.svc:80
+            - -tests.read-endpoint=http://mimir-gateway.grafana-mimir.svc:80/prometheus
+            - -tests.tenant-id=
+            - -tests.write-read-series-test.num-series=1000
+            - -tests.write-read-series-test.max-query-age=48h
+            - -server.metrics-port=8080
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: grafana/mimir-continuous-test:2.11.0
+          imagePullPolicy: IfNotPresent
+          name: smoke-test
+          volumeMounts: null
+      initContainers: []
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      volumes: null

--- a/input/grafana-mimir/manifests/Namespace_grafana-mimir.yaml
+++ b/input/grafana-mimir/manifests/Namespace_grafana-mimir.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana-mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-chunks-cache.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-chunks-cache.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: chunks-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-chunks-cache
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: chunks-cache
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-compactor.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-compactor.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-compactor
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-distributor.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-distributor.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-distributor
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-gateway.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-gateway.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-gateway
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: gateway
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-index-cache.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-index-cache.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: index-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-index-cache
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: index-cache
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-ingester.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-ingester.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-ingester
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-metadata-cache.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-metadata-cache.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-metadata-cache
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata-cache
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-overrides-exporter.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-overrides-exporter.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-overrides-exporter
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: overrides-exporter
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-querier.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-querier.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-querier
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: querier
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-query-frontend.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-query-frontend.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-query-frontend
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-query-scheduler.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-query-scheduler.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-query-scheduler
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-scheduler
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-results-cache.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-results-cache.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: results-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-results-cache
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: results-cache
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-store-gateway.yaml
+++ b/input/grafana-mimir/manifests/PodDisruptionBudget_mimir-store-gateway.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-store-gateway
+  namespace: grafana-mimir
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir

--- a/input/grafana-mimir/manifests/RoleBinding_mimir-rollout-operator.yaml
+++ b/input/grafana-mimir/manifests/RoleBinding_mimir-rollout-operator.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mimir-rollout-operator
+  namespace: grafana-mimir
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mimir-rollout-operator
+subjects:
+  - kind: ServiceAccount
+    name: mimir-rollout-operator

--- a/input/grafana-mimir/manifests/Role_mimir-rollout-operator.yaml
+++ b/input/grafana-mimir/manifests/Role_mimir-rollout-operator.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mimir-rollout-operator
+  namespace: grafana-mimir
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/status
+    verbs:
+      - update

--- a/input/grafana-mimir/manifests/ServiceAccount_mimir-rollout-operator.yaml
+++ b/input/grafana-mimir/manifests/ServiceAccount_mimir-rollout-operator.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mimir-rollout-operator
+  namespace: grafana-mimir
+  labels:
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/version: v0.9.0

--- a/input/grafana-mimir/manifests/ServiceAccount_mimir.yaml
+++ b/input/grafana-mimir/manifests/ServiceAccount_mimir.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir
+  namespace: grafana-mimir

--- a/input/grafana-mimir/manifests/Service_mimir-chunks-cache.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-chunks-cache.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: chunks-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-chunks-cache
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+  selector:
+    app.kubernetes.io/component: chunks-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-compactor.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-compactor.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-compactor
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-distributor-headless.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-distributor-headless.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    prometheus.io/service-monitor: "false"
+  name: mimir-distributor-headless
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-distributor.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-distributor.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-distributor
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-gateway.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-gateway.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-gateway
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 80
+      protocol: TCP
+      targetPort: http-metrics
+    - name: legacy-http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+  selector:
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP
+  clusterIP: 10.43.245.229 ## Static IP

--- a/input/grafana-mimir/manifests/Service_mimir-gossip-ring.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-gossip-ring.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: gossip-ring
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-gossip-ring
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - appProtocol: tcp
+      name: gossip-ring
+      port: 7946
+      protocol: TCP
+      targetPort: 7946
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-index-cache.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-index-cache.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: index-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-index-cache
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+  selector:
+    app.kubernetes.io/component: index-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-ingester-headless.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-ingester-headless.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    prometheus.io/service-monitor: "false"
+  name: mimir-ingester-headless
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-ingester-zone-a.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-ingester-zone-a.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: ingester-zone-a
+    rollout-group: ingester
+    zone: zone-a
+  name: mimir-ingester-zone-a
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    rollout-group: ingester
+    zone: zone-a
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-ingester-zone-b.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-ingester-zone-b.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: ingester-zone-b
+    rollout-group: ingester
+    zone: zone-b
+  name: mimir-ingester-zone-b
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    rollout-group: ingester
+    zone: zone-b
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-ingester-zone-c.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-ingester-zone-c.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: ingester-zone-c
+    rollout-group: ingester
+    zone: zone-c
+  name: mimir-ingester-zone-c
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    rollout-group: ingester
+    zone: zone-c
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-metadata-cache.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-metadata-cache.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: metadata-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-metadata-cache
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+  selector:
+    app.kubernetes.io/component: metadata-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-overrides-exporter.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-overrides-exporter.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-overrides-exporter
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-querier.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-querier.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-querier
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-query-frontend.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-query-frontend.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-query-frontend
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-query-scheduler-headless.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-query-scheduler-headless.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+    prometheus.io/service-monitor: "false"
+  name: mimir-query-scheduler-headless
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-query-scheduler.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-query-scheduler.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-query-scheduler
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-results-cache.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-results-cache.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: results-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-results-cache
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+  selector:
+    app.kubernetes.io/component: results-cache
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-store-gateway-headless.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-store-gateway-headless.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    prometheus.io/service-monitor: "false"
+  name: mimir-store-gateway-headless
+  namespace: grafana-mimir
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-store-gateway-zone-a.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-store-gateway-zone-a.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: store-gateway-zone-a
+    rollout-group: store-gateway
+    zone: zone-a
+  name: mimir-store-gateway-zone-a
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    rollout-group: store-gateway
+    zone: zone-a
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-store-gateway-zone-b.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-store-gateway-zone-b.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: store-gateway-zone-b
+    rollout-group: store-gateway
+    zone: zone-b
+  name: mimir-store-gateway-zone-b
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    rollout-group: store-gateway
+    zone: zone-b
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/Service_mimir-store-gateway-zone-c.yaml
+++ b/input/grafana-mimir/manifests/Service_mimir-store-gateway-zone-c.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: store-gateway-zone-c
+    rollout-group: store-gateway
+    zone: zone-c
+  name: mimir-store-gateway-zone-c
+  namespace: grafana-mimir
+spec:
+  ports:
+    - name: http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: http-metrics
+    - name: grpc
+      port: 9095
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    rollout-group: store-gateway
+    zone: zone-c
+  type: ClusterIP

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-chunks-cache.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-chunks-cache.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-chunks-cache
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: Parallel
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: chunks-cache
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  serviceName: mimir-chunks-cache
+  template:
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: chunks-cache
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -m 200
+            - --extended=modern,track_sizes
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: memcached:1.6.22-alpine
+          imagePullPolicy: IfNotPresent
+          name: memcached
+          ports:
+            - containerPort: 11211
+              name: client
+          resources:
+            limits:
+              memory: 240Mi
+            requests:
+              cpu: 500m
+              memory: 240Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+        - args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: prom/memcached-exporter:v0.14.2
+          imagePullPolicy: IfNotPresent
+          name: exporter
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 60
+      tolerations: []
+  updateStrategy:
+    type: RollingUpdate

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-compactor.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-compactor.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-compactor
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: compactor
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  serviceName: mimir-compactor
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+      namespace: grafana-mimir
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -target=compactor
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: compactor
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            limits:
+              memory: 1000Mi
+            requests:
+              cpu: 1.5
+              memory: 700Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 240
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: compactor
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: active-queries
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+        storageClassName: longhorn-default

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-index-cache.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-index-cache.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-index-cache
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: index-cache
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  serviceName: mimir-index-cache
+  template:
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: index-cache
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -m 900
+            - --extended=modern,track_sizes
+            - -I 5m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: memcached:1.6.22-alpine
+          imagePullPolicy: IfNotPresent
+          name: memcached
+          ports:
+            - containerPort: 11211
+              name: client
+          resources:
+            limits:
+              memory: 1080Mi
+            requests:
+              cpu: 500m
+              memory: 1080Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+        - args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: prom/memcached-exporter:v0.14.2
+          imagePullPolicy: IfNotPresent
+          name: exporter
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 60
+      tolerations: []
+  updateStrategy:
+    type: RollingUpdate

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-ingester-zone-a.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-ingester-zone-a.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: ingester-zone-a
+    rollout-group: ingester
+    zone: zone-a
+  name: mimir-ingester-zone-a
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+      rollout-group: ingester
+      zone: zone-a
+  serviceName: mimir-ingester-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+        name: ingester-zone-a
+        rollout-group: ingester
+        zone: zone-a
+      namespace: grafana-mimir
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: rollout-group
+                    operator: In
+                    values:
+                      - ingester
+                  - key: zone
+                    operator: NotIn
+                    values:
+                      - zone-a
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - -target=ingester
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+            - -ingester.ring.instance-availability-zone=zone-a
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: ingester
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            limits:
+              memory: 12Gi
+            requests:
+              cpu: 1
+              memory: 9Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 240
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: ingester
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: active-queries
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
+        storageClassName: longhorn-default

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-ingester-zone-b.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-ingester-zone-b.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: ingester-zone-b
+    rollout-group: ingester
+    zone: zone-b
+  name: mimir-ingester-zone-b
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+      rollout-group: ingester
+      zone: zone-b
+  serviceName: mimir-ingester-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+        name: ingester-zone-b
+        rollout-group: ingester
+        zone: zone-b
+      namespace: grafana-mimir
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: rollout-group
+                    operator: In
+                    values:
+                      - ingester
+                  - key: zone
+                    operator: NotIn
+                    values:
+                      - zone-b
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - -target=ingester
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+            - -ingester.ring.instance-availability-zone=zone-b
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: ingester
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            limits:
+              memory: 12Gi
+            requests:
+              cpu: 1
+              memory: 9Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 240
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: ingester
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: active-queries
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
+        storageClassName: longhorn-default

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-ingester-zone-c.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-ingester-zone-c.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: ingester-zone-c
+    rollout-group: ingester
+    zone: zone-c
+  name: mimir-ingester-zone-c
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ingester
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+      rollout-group: ingester
+      zone: zone-c
+  serviceName: mimir-ingester-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+        name: ingester-zone-c
+        rollout-group: ingester
+        zone: zone-c
+      namespace: grafana-mimir
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: rollout-group
+                    operator: In
+                    values:
+                      - ingester
+                  - key: zone
+                    operator: NotIn
+                    values:
+                      - zone-c
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - -target=ingester
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+            - -ingester.ring.instance-availability-zone=zone-c
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: ingester
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            limits:
+              memory: 12Gi
+            requests:
+              cpu: 1
+              memory: 9Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 240
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: ingester
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: active-queries
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
+        storageClassName: longhorn-default

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-metadata-cache.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-metadata-cache.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-metadata-cache
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata-cache
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  serviceName: mimir-metadata-cache
+  template:
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: metadata-cache
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -m 120
+            - --extended=modern,track_sizes
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: memcached:1.6.22-alpine
+          imagePullPolicy: IfNotPresent
+          name: memcached
+          ports:
+            - containerPort: 11211
+              name: client
+          resources:
+            limits:
+              memory: 144Mi
+            requests:
+              cpu: 500m
+              memory: 144Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+        - args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: prom/memcached-exporter:v0.14.2
+          imagePullPolicy: IfNotPresent
+          name: exporter
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 60
+      tolerations: []
+  updateStrategy:
+    type: RollingUpdate

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-results-cache.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-results-cache.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/version: 2.11.0
+  name: mimir-results-cache
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: Parallel
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: results-cache
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+  serviceName: mimir-results-cache
+  template:
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: results-cache
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/version: 2.11.0
+    spec:
+      affinity: {}
+      containers:
+        - args:
+            - -m 120
+            - --extended=modern,track_sizes
+            - -I 5m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+          envFrom: null
+          image: memcached:1.6.22-alpine
+          imagePullPolicy: IfNotPresent
+          name: memcached
+          ports:
+            - containerPort: 11211
+              name: client
+          resources:
+            limits:
+              memory: 144Mi
+            requests:
+              cpu: 500m
+              memory: 144Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+        - args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: prom/memcached-exporter:v0.14.2
+          imagePullPolicy: IfNotPresent
+          name: exporter
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 60
+      tolerations: []
+  updateStrategy:
+    type: RollingUpdate

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-store-gateway-zone-a.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-store-gateway-zone-a.yaml
@@ -1,0 +1,163 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: store-gateway-zone-a
+    rollout-group: store-gateway
+    zone: zone-a
+  name: mimir-store-gateway-zone-a
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+      rollout-group: store-gateway
+      zone: zone-a
+  serviceName: mimir-store-gateway-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+        name: store-gateway-zone-a
+        rollout-group: store-gateway
+        zone: zone-a
+      namespace: grafana-mimir
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: rollout-group
+                    operator: In
+                    values:
+                      - store-gateway
+                  - key: zone
+                    operator: NotIn
+                    values:
+                      - zone-a
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - -target=store-gateway
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+            - -store-gateway.sharding-ring.instance-availability-zone=zone-a
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+            - name: GOMAXPROCS
+              value: "5"
+            - name: GOMEMLIMIT
+              value: "734003200"
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: store-gateway
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            limits:
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 700Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 240
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: store-gateway
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: active-queries
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-store-gateway-zone-b.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-store-gateway-zone-b.yaml
@@ -1,0 +1,163 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: store-gateway-zone-b
+    rollout-group: store-gateway
+    zone: zone-b
+  name: mimir-store-gateway-zone-b
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+      rollout-group: store-gateway
+      zone: zone-b
+  serviceName: mimir-store-gateway-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+        name: store-gateway-zone-b
+        rollout-group: store-gateway
+        zone: zone-b
+      namespace: grafana-mimir
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: rollout-group
+                    operator: In
+                    values:
+                      - store-gateway
+                  - key: zone
+                    operator: NotIn
+                    values:
+                      - zone-b
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - -target=store-gateway
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+            - -store-gateway.sharding-ring.instance-availability-zone=zone-b
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+            - name: GOMAXPROCS
+              value: "5"
+            - name: GOMEMLIMIT
+              value: "734003200"
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: store-gateway
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            limits:
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 700Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 240
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: store-gateway
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: active-queries
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi

--- a/input/grafana-mimir/manifests/StatefulSet_mimir-store-gateway-zone-c.yaml
+++ b/input/grafana-mimir/manifests/StatefulSet_mimir-store-gateway-zone-c.yaml
@@ -1,0 +1,163 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/version: 2.11.0
+    name: store-gateway-zone-c
+    rollout-group: store-gateway
+    zone: zone-c
+  name: mimir-store-gateway-zone-c
+  namespace: grafana-mimir
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: store-gateway
+      app.kubernetes.io/instance: mimir
+      app.kubernetes.io/name: mimir
+      rollout-group: store-gateway
+      zone: zone-c
+  serviceName: mimir-store-gateway-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config: a1e3521abdc720c1f63bc0b567c5ff2e8199c841e90c95f770e2f4bdb8b00ae6
+      labels:
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/instance: mimir
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/part-of: memberlist
+        app.kubernetes.io/version: 2.11.0
+        name: store-gateway-zone-c
+        rollout-group: store-gateway
+        zone: zone-c
+      namespace: grafana-mimir
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: rollout-group
+                    operator: In
+                    values:
+                      - store-gateway
+                  - key: zone
+                    operator: NotIn
+                    values:
+                      - zone-c
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - -target=store-gateway
+            - -config.expand-env=true
+            - -config.file=/etc/mimir/mimir.yaml
+            - -store-gateway.sharding-ring.instance-availability-zone=zone-c
+          env:
+            - name: API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_ACCESS_KEY
+                  name: mimir-minio-creds
+            - name: API_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SECRET_KEY
+                  name: mimir-minio-creds
+            - name: GOMAXPROCS
+              value: "5"
+            - name: GOMEMLIMIT
+              value: "734003200"
+          envFrom: null
+          image: grafana/mimir:2.11.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe: null
+          name: store-gateway
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9095
+              name: grpc
+              protocol: TCP
+            - containerPort: 7946
+              name: memberlist
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            limits:
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 700Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/mimir
+              name: config
+            - mountPath: /var/mimir
+              name: runtime-config
+            - mountPath: /data
+              name: storage
+            - mountPath: /active-query-tracker
+              name: active-queries
+      initContainers: []
+      nodeSelector: {}
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mimir
+      terminationGracePeriodSeconds: 240
+      tolerations: []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: store-gateway
+              app.kubernetes.io/instance: mimir
+              app.kubernetes.io/name: mimir
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - configMap:
+            items:
+              - key: mimir.yaml
+                path: mimir.yaml
+            name: mimir-config
+          name: config
+        - configMap:
+            name: mimir-runtime
+          name: runtime-config
+        - emptyDir: {}
+          name: active-queries
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi


### PR DESCRIPTION
This PR add the manifests of grafana-loki and grafana-mimir created by "smelt" step.

A highligt point is that mimir-gateway and loki-gateway service objects have static IPs for giving fixed IPs to headscale tunnel ends.

- [Service_loki-gateway.yaml](https://github.com/silogen/cluster-forge/blob/bafb364fca5edd6c27daf5cbc39b543881d1a4aa/input/grafana-loki/manifests/Service_loki-gateway.yaml#L24)
- [Service_mimir-gateway.yaml](https://github.com/silogen/cluster-forge/blob/bafb364fca5edd6c27daf5cbc39b543881d1a4aa/input/grafana-mimir/manifests/Service_mimir-gateway.yaml#L28)