### PR TITLE
Update log collector and grafana loki to add filter labels

### DIFF
--- a/input/grafana-loki/grafana-loki-values.yaml
+++ b/input/grafana-loki/grafana-loki-values.yaml
@@ -19,6 +19,13 @@ loki:
     ingestion_rate_mb: 20
     ingestion_burst_size_mb: 30
     query_timeout: 120s
+    otlp_config:
+      resource_attributes:
+        attributes_config:
+          - action: index_label
+            attributes:
+              - component.id
+              - workload.id
   ingester:
     autoforget_unhealthy: true
     chunk_encoding: snappy

--- a/input/grafana-loki/manifests/sourced/ConfigMap_loki.yaml
+++ b/input/grafana-loki/manifests/sourced/ConfigMap_loki.yaml
@@ -61,6 +61,13 @@ data:
       ingestion_burst_size_mb: 30
       ingestion_rate_mb: 20
       max_cache_freshness_per_query: 10m
+      otlp_config:
+        resource_attributes:
+          attributes_config:
+          - action: index_label
+            attributes:
+            - component.id
+            - workload.id
       query_timeout: 120s
       reject_old_samples: true
       reject_old_samples_max_age: 168h

--- a/input/grafana-loki/manifests/sourced/Deployment_loki-read.yaml
+++ b/input/grafana-loki/manifests/sourced/Deployment_loki-read.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dbb440eae4bc22dc6ba70cea6930e5ba6eb2321b301104648789f9ae5b15be0a
+        checksum/config: 75d499fc3048d749fe2709cbe205cf514cbce4e104a4ee2c0e3312c9dc3f0412
       labels:
         app.kubernetes.io/component: read
         app.kubernetes.io/instance: loki

--- a/input/grafana-loki/manifests/sourced/StatefulSet_loki-backend.yaml
+++ b/input/grafana-loki/manifests/sourced/StatefulSet_loki-backend.yaml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dbb440eae4bc22dc6ba70cea6930e5ba6eb2321b301104648789f9ae5b15be0a
+        checksum/config: 75d499fc3048d749fe2709cbe205cf514cbce4e104a4ee2c0e3312c9dc3f0412
       labels:
         app.kubernetes.io/component: backend
         app.kubernetes.io/instance: loki

--- a/input/grafana-loki/manifests/sourced/StatefulSet_loki-write.yaml
+++ b/input/grafana-loki/manifests/sourced/StatefulSet_loki-write.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dbb440eae4bc22dc6ba70cea6930e5ba6eb2321b301104648789f9ae5b15be0a
+        checksum/config: 75d499fc3048d749fe2709cbe205cf514cbce4e104a4ee2c0e3312c9dc3f0412
       labels:
         app.kubernetes.io/component: write
         app.kubernetes.io/instance: loki

--- a/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
@@ -322,6 +322,8 @@ spec:
           - context: log
             statements:
               - set(resource.attributes["k8s.cluster.name"], attributes["k8s.cluster.name"])
+              - set(resource.attributes["component.id"], attributes["component.id"])
+              - set(resource.attributes["workload.id"], attributes["workload.id"])
       batch:
         send_batch_size: 2000
         timeout: 10s
@@ -344,6 +346,12 @@ spec:
           - from: pod
             key: app.kubernetes.io/component
             tag_name: k8s.app.component
+          - from: pod
+            key: airm.silogen.ai/component-id
+            tag_name: component.id
+          - from: pod
+            key: airm.silogen.ai/workload-id
+            tag_name: workload.id
           metadata:
           - k8s.namespace.name
           - k8s.pod.name


### PR DESCRIPTION
This PR updates otel-log-collector and grafana-loki to add new two labels as filter labels.
Verified with otel-log-collector in oci2 and grafana-loki in ociops.

- Two new labels
- "workload-id": From pod label airm.silogen.ai/workload-id
- "component-id": From pod label airm.silogen.ai/component-id

This is requested by @juhovainio

