### PR TITLE
Update to add additional tenant to loki

### DIFF
--- a/input/1password-cluster-secret-store/manifests/ExternalSecret_grafana-loki.yaml
+++ b/input/1password-cluster-secret-store/manifests/ExternalSecret_grafana-loki.yaml
@@ -13,6 +13,10 @@ spec:
       key: ociops-monitoring-credentials
       property: loki_tenant_password_ociclusters
     secretKey: loki_tenant_password_ociclusters 
+  - remoteRef:
+      key: ociops-monitoring-credentials
+      property: loki_tenant_name_ociops
+    secretKey: loki_tenant_name_ociops
   refreshInterval: "0" 
   secretStoreRef:
     kind: ClusterSecretStore

--- a/input/grafana-loki/grafana-loki-values.yaml
+++ b/input/grafana-loki/grafana-loki-values.yaml
@@ -11,7 +11,9 @@ loki:
       heartbeat_timeout: "10m"
   auth_enabled: true
   tenants: ## promtail
-    - name: ${TENANT_NAME}
+    - name: ${TENANT_NAME_OCICLUSTERS}
+      password: ${TENANT_PW}
+    - name: ${TENANT_NAME_OCIOPS}
       password: ${TENANT_PW}
   limits_config:
     index_gateway_shard_size: 1
@@ -141,6 +143,10 @@ extraObjects:
           remoteRef:
             key: grafana-loki-creds
             property: loki_tenant_name_oci
+        - secretKey: loki_tenant_name_ociops
+          remoteRef:
+            key: grafana-loki-creds
+            property: loki_tenant_name_ociops
         - secretKey: loki_tenant_password_ociclusters
           remoteRef:
             key: grafana-loki-creds
@@ -161,7 +167,7 @@ backend:
         secretKeyRef:
           name: loki-minio-creds
           key: API_SECRET_KEY
-    - name: TENANT_NAME
+    - name: TENANT_NAME_OCICLUSTERS
       valueFrom:
         secretKeyRef:
           name: loki-tenant-creds
@@ -171,6 +177,11 @@ backend:
         secretKeyRef:
           name: loki-tenant-creds
           key: loki_tenant_password_ociclusters
+    - name: TENANT_NAME_OCIOPS
+      valueFrom:
+        secretKeyRef:
+          name: loki-tenant-creds
+          key: loki_tenant_name_ociops
 write:
   persistence:
     storageClass: longhorn-default
@@ -187,7 +198,7 @@ write:
         secretKeyRef:
           name: loki-minio-creds
           key: API_SECRET_KEY
-    - name: TENANT_NAME
+    - name: TENANT_NAME_OCICLUSTERS
       valueFrom:
         secretKeyRef:
           name: loki-tenant-creds
@@ -197,6 +208,11 @@ write:
         secretKeyRef:
           name: loki-tenant-creds
           key: loki_tenant_password_ociclusters
+    - name: TENANT_NAME_OCIOPS
+      valueFrom:
+        secretKeyRef:
+          name: loki-tenant-creds
+          key: loki_tenant_name_ociops
 read:
   persistence:
     storageClass: longhorn-default
@@ -213,7 +229,7 @@ read:
         secretKeyRef:
           name: loki-minio-creds
           key: API_SECRET_KEY
-    - name: TENANT_NAME
+    - name: TENANT_NAME_OCICLUSTERS
       valueFrom:
         secretKeyRef:
           name: loki-tenant-creds
@@ -223,5 +239,11 @@ read:
         secretKeyRef:
           name: loki-tenant-creds
           key: loki_tenant_password_ociclusters
+    - name: TENANT_NAME_OCIOPS
+      valueFrom:
+        secretKeyRef:
+          name: loki-tenant-creds
+          key: loki_tenant_name_ociops
+
 minio:
   enabled: false

--- a/input/grafana-loki/manifests/sourced/Deployment_loki-read.yaml
+++ b/input/grafana-loki/manifests/sourced/Deployment_loki-read.yaml
@@ -58,7 +58,7 @@ spec:
                 secretKeyRef:
                   key: API_SECRET_KEY
                   name: loki-minio-creds
-            - name: TENANT_NAME
+            - name: TENANT_NAME_OCICLUSTERS
               valueFrom:
                 secretKeyRef:
                   key: loki_tenant_name_oci
@@ -67,6 +67,11 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: loki_tenant_password_ociclusters
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCIOPS
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ociops
                   name: loki-tenant-creds
           image: docker.io/grafana/loki:3.1.1
           imagePullPolicy: IfNotPresent

--- a/input/grafana-loki/manifests/sourced/ExternalSecret_loki-tenant-creds.yaml
+++ b/input/grafana-loki/manifests/sourced/ExternalSecret_loki-tenant-creds.yaml
@@ -12,6 +12,10 @@ spec:
       secretKey: loki_tenant_name_oci
     - remoteRef:
         key: grafana-loki-creds
+        property: loki_tenant_name_ociops
+      secretKey: loki_tenant_name_ociops
+    - remoteRef:
+        key: grafana-loki-creds
         property: loki_tenant_password_ociclusters
       secretKey: loki_tenant_password_ociclusters
   refreshInterval: "0"

--- a/input/grafana-loki/manifests/sourced/Service_loki-gateway.yaml
+++ b/input/grafana-loki/manifests/sourced/Service_loki-gateway.yaml
@@ -21,3 +21,4 @@ spec:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
   type: ClusterIP
+  clusterIP: 10.243.184.169 ## Static IP

--- a/input/grafana-loki/manifests/sourced/StatefulSet_loki-backend.yaml
+++ b/input/grafana-loki/manifests/sourced/StatefulSet_loki-backend.yaml
@@ -79,7 +79,7 @@ spec:
                 secretKeyRef:
                   key: API_SECRET_KEY
                   name: loki-minio-creds
-            - name: TENANT_NAME
+            - name: TENANT_NAME_OCICLUSTERS
               valueFrom:
                 secretKeyRef:
                   key: loki_tenant_name_oci
@@ -88,6 +88,11 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: loki_tenant_password_ociclusters
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCIOPS
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ociops
                   name: loki-tenant-creds
           image: docker.io/grafana/loki:3.1.1
           imagePullPolicy: IfNotPresent

--- a/input/grafana-loki/manifests/sourced/StatefulSet_loki-write.yaml
+++ b/input/grafana-loki/manifests/sourced/StatefulSet_loki-write.yaml
@@ -54,7 +54,7 @@ spec:
                 secretKeyRef:
                   key: API_SECRET_KEY
                   name: loki-minio-creds
-            - name: TENANT_NAME
+            - name: TENANT_NAME_OCICLUSTERS
               valueFrom:
                 secretKeyRef:
                   key: loki_tenant_name_oci
@@ -63,6 +63,11 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: loki_tenant_password_ociclusters
+                  name: loki-tenant-creds
+            - name: TENANT_NAME_OCIOPS
+              valueFrom:
+                secretKeyRef:
+                  key: loki_tenant_name_ociops
                   name: loki-tenant-creds
           image: docker.io/grafana/loki:3.1.1
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This PR adds a dedicated tenant to grafana-loki to monitor tools in ops cluster.