### PR TITLE
Cleanup keycloak realm in preparation for kubectl access control

### DIFF
--- a/input/keycloak-config/airm-realm-configmap.yaml
+++ b/input/keycloak-config/airm-realm-configmap.yaml
@@ -702,27 +702,6 @@ data:
           "authenticationFlowBindingOverrides": {},
           "fullScopeAllowed": true,
           "nodeReRegistrationTimeout": -1,
-          "protocolMappers": [
-            {
-              "id": "c5b1f35a-11a3-4eb2-8abc-7c1a422edb3a",
-              "name": "organization",
-              "protocol": "openid-connect",
-              "protocolMapper": "oidc-organization-membership-mapper",
-              "consentRequired": false,
-              "config": {
-                "introspection.token.claim": "true",
-                "multivalued": "true",
-                "userinfo.token.claim": "true",
-                "addOrganizationAttributes": "true",
-                "id.token.claim": "true",
-                "lightweight.claim": "false",
-                "access.token.claim": "true",
-                "claim.name": "organization",
-                "jsonType.label": "JSON",
-                "addOrganizationId": "true"
-              }
-            }
-          ],
           "defaultClientScopes": [
             "web-origins",
             "acr",
@@ -1142,7 +1121,8 @@ data:
                 "id.token.claim": "true",
                 "access.token.claim": "true",
                 "claim.name": "organization",
-                "jsonType.label": "String"
+                "jsonType.label": "JSON",
+                "addOrganizationId": "true"
               }
             }
           ]
@@ -1164,10 +1144,12 @@ data:
               "protocolMapper": "oidc-group-membership-mapper",
               "consentRequired": false,
               "config": {
+                "full.path": "false",
                 "introspection.token.claim": "true",
                 "multivalued": "true",
                 "userinfo.token.claim": "true",
-                "id.token.claim": "false",
+                "id.token.claim": "true",
+                "lightweight.claim": "false",
                 "access.token.claim": "true",
                 "claim.name": "groups",
                 "jsonType.label": "String"


### PR DESCRIPTION
In preparation for access control in kubectl, the groups the user belongs to must be part of the ID token of the user.

Also, use the opportunity to cleanup the organization claim to remove the custom mapper