### PR TITLE
Fix configuration for email registration from AIRMan

### DIFF
--- a/input/airm-airm-config/airm.yaml
+++ b/input/airm-airm-config/airm.yaml
@@ -59,7 +59,7 @@ spec:
             - name: OPENID_CONFIGURATION_URL
               value: http://kc.not-a-domain/realms/airm/.well-known/openid-configuration
             - name: POST_REGISTRATION_REDIRECT_URL
-              value: https://airm.not-a-domain/
+              value: https://airmui.not-a-domain/
             - name: CLUSTER_BASE_URL
               value: https://workspaces.not-a-domain/
             - name: DATABASE_HOST

--- a/input/keycloak-config/airm-realm-configmap.yaml
+++ b/input/keycloak-config/airm-realm-configmap.yaml
@@ -569,6 +569,7 @@ data:
           "secret": "__AIRM_ADMIN_CLIENT_SECRET__",
           "redirectUris": [
             "https://not-a-domain/*",
+            "https://airmui.not-a-domain/*",
             "https://*.not-a-domain/*"
           ],
           "webOrigins": [


### PR DESCRIPTION
The email domains for the redirect URIs didnt line up