### PR TITLE
Add chrony-exporter and add a scrape job for chrony

### DIFF
--- a/input/otel-lgtm-stack/node-exporter/chrony-node-exporter.yaml
+++ b/input/otel-lgtm-stack/node-exporter/chrony-node-exporter.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nodeexporter-chrony-exporter
+  namespace: otel-lgtm-stack
+  labels:
+    app: chrony-exporter
+spec:
+  selector:
+    matchLabels:
+      app: chrony-exporter
+  template:
+    metadata:
+      labels:
+        app: chrony-exporter
+    spec:
+      containers:
+        - name: chrony-exporter
+          image: quay.io/superq/chrony-exporter:v0.12.1
+          args:
+            - "--chrony.address=unix:///run/chrony/chronyd.sock"
+            - "--collector.chmod-socket"
+            - "--collector.sources"
+            - "--collector.tracking"
+            - "--log.level=info"
+          securityContext:
+            runAsUser: 0
+          ports:
+            - containerPort: 9123
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /run/chrony/
+              name: chronyd-socket
+      volumes:
+        - name: chronyd-socket
+          hostPath:
+            path: /run/chrony/
+            type: Directory
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi

--- a/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
+++ b/input/otel-lgtm-stack/otel-collectors/collector-manifests.yaml
@@ -921,23 +921,19 @@ spec:
               static_configs:
                 - targets:
                     - longhorn-backend.longhorn.svc.cluster.local:9500
-            - job_name: airm-custom-metrics
+            - job_name: chrony-exporter
               kubernetes_sd_configs:
                 - role: pod
-              metrics_path: /
               relabel_configs:
-                - action: keep
-                  regex: airm-api
-                  source_labels:
-                    - __meta_kubernetes_pod_label_app
-                - regex: (.+)
-                  replacement: $1:9009
-                  source_labels:
-                    - __meta_kubernetes_node_address_InternalIP
+                - source_labels: [__meta_kubernetes_pod_label_app]
+                  regex: chrony-exporter
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_ip]
                   target_label: __address__
-                - source_labels:
-                    - __meta_kubernetes_node_name
-                  target_label: hostname
+                  regex: (.*)
+                  replacement: $1:9123
+                - source_labels: [__meta_kubernetes_pod_node_name]
+                  target_label: k8s_node_name
     service:
       pipelines:
         metrics:


### PR DESCRIPTION
This PR adds chrony-exporters using Daemonset and adds a chrony scrape job.
There is a dedicated metric collector for airm-metrics. So the duplicated scrape job for airm-custom metric is deleted.