### PR TITLE
feat: add options to disable selfHeal

### DIFF
--- a/root/templates/cluster-apps.yaml
+++ b/root/templates/cluster-apps.yaml
@@ -52,7 +52,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
-      selfHeal: true
+      selfHeal: {{ hasKey $scope "selfHeal" | ternary $scope.selfHeal true }}
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/root/templates/cluster-forge.yaml
+++ b/root/templates/cluster-forge.yaml
@@ -38,4 +38,4 @@ spec:
   syncPolicy:
     automated:
       prune: true
-      selfHeal: true
+      selfHeal: {{ hasKey .Values.clusterForge "selfHeal" | ternary .Values.clusterForge.selfHeal true }}


### PR DESCRIPTION
## Summary

- Add option to disable ArgoCD `selfHeal` on cluster-apps and cluster-forge root apps — required for e2e tests where ArgoCD would otherwise revert test-created resources
## Test plan

- [ ] Verify cluster-forge deploys successfully with selfHeal enabled (default behaviour unchanged)
- [x] Verify e2e tests can set `selfHeal: false` via values to prevent ArgoCD reverting test resources
- [x] Verify airm/aiwb apps no longer show as out-of-sync due to ExternalSecret operator fields