### PR TITLE
EAI_2309 Openbao init fix

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -745,15 +745,7 @@ apps:
     path: openbao-config/0.1.0
     syncWave: -60
     valuesFile: values.yaml
-  openbao-init:
-    helmParameters:
-      - name: domain
-        value: "{{ .Values.global.domain }}"
-    namespace: cf-openbao
-    path: ../scripts/init-openbao-job
-    syncWave: -50
-    valuesObject:
-      domain: # to be filled by cluster-forge app
+
   opentelemetry-operator:
     namespace: opentelemetry-operator-system
     path: opentelemetry-operator/0.93.1

--- a/root/values_large.yaml
+++ b/root/values_large.yaml
@@ -45,7 +45,6 @@ enabledApps:
   - minio-tenant-config
   - openbao
   - openbao-config
-  - openbao-init
   - opentelemetry-operator
   - otel-lgtm-stack
   - prometheus-crds

--- a/root/values_small.yaml
+++ b/root/values_small.yaml
@@ -46,7 +46,6 @@ enabledApps:
   - minio-tenant-config
   - openbao
   - openbao-config
-  - openbao-init
   - opentelemetry-operator
   - otel-lgtm-stack
   - prometheus-crds

--- a/sbom/components.yaml
+++ b/sbom/components.yaml
@@ -244,12 +244,7 @@ components:
     projectUrl: https://github.com/openbao/openbao
     license: Mozilla Public License 2.0
     licenseUrl: https://github.com/openbao/openbao/blob/main/LICENSE
-  openbao-init:
-    path: ../scripts/init-openbao-job
-    sourceUrl: https://github.com/silogen/cluster-forge/tree/main/scripts/init-openbao-job
-    projectUrl: https://github.com/silogen/cluster-forge/
-    license: Apache License 2.0
-    licenseUrl: https://github.com/silogen/cluster-forge/blob/main/LICENSE
+
   opentelemetry-operator:
     path: opentelemetry-operator/0.93.1
     sourceUrl: https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
Summary: Fix OpenBao Init Job Rerun on TargetRevision Changes

Problem
When updating targetRevision in cluster-values.yaml, the openbao-init-job would rerun unnecessarily, causing the openbao-config application to get stuck in a progressing state. This violated the design principle that initialization should only occur once during bootstrap.

Root Cause
The openbao-init-job was incorrectly managed as a persistent ArgoCD application in cluster-forge/root/values.yaml. This meant every targetRevision change triggered ArgoCD to sync the init job, causing it to rerun when it should only execute during initial cluster bootstrap.

Solution
Removed openbao-init from ArgoCD application management while preserving its bootstrap functionality:
- Removed openbao-init application definition from values.yaml
- Removed from enabledApps lists in size-specific configuration files
- Removed from SBOM components list
- Preserved existing bootstrap logic in scripts/bootstrap.sh

Result
- ✅ Init job runs only once during bootstrap
- ✅ No rerun on targetRevision changes
- ✅ openbao-config no longer gets stuck in progressing state
