### PR TITLE
EAI-6059 Prepare Pluggable S3 instructions for changes in upstream

### DIFF
--- a/docs/manual_helm_install/components/db.md
+++ b/docs/manual_helm_install/components/db.md
@@ -1,272 +1,110 @@
-# Pluggable PostgreSQL Compatible Database
+# Pluggable PostgreSQL Database
 
-This guide describes how to replace the ClusterForge-managed PostgreSQL database with your own external PostgreSQL instance.
-
-## Overview
-
-ClusterForge provisions your Kubernetes cluster with AIWB and Keycloak already deployed and connected to an in-cluster PostgreSQL database managed by CloudNativePG (CNPG). The AIWB and Keycloak deployments are pre-configured with hardcoded database usernames that match this CNPG installation.
-
-These instructions walk you through:
-
-1. Setting up your own external PostgreSQL server with the required databases and users
-2. Removing the CNPG cluster resources from the `aiwb` and `keycloak` namespaces
-3. Patching the Kubernetes secrets and deployments that ClusterForge created so that AIWB and Keycloak connect to your database instead
+Cluster Forge can be installed against an external PostgreSQL server instead
+of the in-cluster CloudNativePG (CNPG) Clusters. In this mode `install_base.sh`
+skips the cnpg-operator install, skips the Cluster CRs in the AIWB and
+Keycloak charts, and creates the user Secrets that AIWB and Keycloak read at
+startup directly from environment variables.
 
 ## Prerequisites
 
-1. **PostgreSQL 12 or later** is installed and running
-2. **kubectl** is installed and configured to access your ClusterForge cluster
-3. **Network connectivity** between your Kubernetes cluster and your PostgreSQL server
+- PostgreSQL 12 or later, reachable from the cluster
+- Two databases pre-created with their own users:
+  - `aiwb` owned by `aiwb_user`
+  - `keycloak` owned by `keycloak`
+- Each user has full privileges on its database (schema `public`, tables,
+  sequences, default privileges)
 
-## Step 1: Configure PostgreSQL
-
-### Network access
-
-PostgreSQL must accept remote connections from Kubernetes pods.
-
-Edit `postgresql.conf`:
-
-```conf
-listen_addresses = '*'
-```
-
-Edit `pg_hba.conf` to allow connections from your cluster and restart PostgreSQL to apply changes:
-
-```conf
-host    aiwb      aiwb_user      0.0.0.0/0       scram-sha-256
-host    keycloak  keycloak       0.0.0.0/0       scram-sha-256
-```
-
-> **Security**: For production, replace `0.0.0.0/0` with your Kubernetes cluster's IP range (e.g. `10.42.0.0/16`).
-
-Verify PostgreSQL is listening on all interfaces:
-
-```bash
-psql -U postgres -c "SHOW listen_addresses"
-# Expected output: * or 0.0.0.0
-```
-
-### Create databases and users
-
-Connect to PostgreSQL and run:
+Example provisioning SQL:
 
 ```sql
--- Create users
 CREATE USER aiwb_user WITH PASSWORD 'your_secure_password';
-CREATE USER keycloak WITH PASSWORD 'your_secure_password';
+CREATE USER keycloak  WITH PASSWORD 'your_secure_password';
 
--- Create databases
-CREATE DATABASE aiwb OWNER aiwb_user;
+CREATE DATABASE aiwb     OWNER aiwb_user;
 CREATE DATABASE keycloak OWNER keycloak;
 
--- Grant privileges
-GRANT ALL PRIVILEGES ON DATABASE aiwb TO aiwb_user;
-GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
-```
-
-Then grant schema-level privileges:
-
-```sql
--- AIWB database
 \c aiwb
 GRANT ALL ON SCHEMA public TO aiwb_user;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO aiwb_user;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO aiwb_user;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO aiwb_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES    TO aiwb_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO aiwb_user;
 
--- Keycloak database
 \c keycloak
 GRANT ALL ON SCHEMA public TO keycloak;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO keycloak;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO keycloak;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES    TO keycloak;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO keycloak;
 ```
 
-## Step 2: Set your configuration variables
+PostgreSQL must accept remote connections from the cluster — set
+`listen_addresses = '*'` in `postgresql.conf` and add `host` rules to
+`pg_hba.conf` for your cluster's pod CIDR.
 
-Set these shell variables before running the kubectl commands below. Replace all placeholder values with your actual database details.
+## Install
 
-```bash
-POSTGRES_HOST="your-db-host"        # e.g. host.docker.internal or db.example.com
-POSTGRES_PORT="5432"
+1. Set environment variables:
 
-AIWB_DB_NAME="aiwb"
-AIWB_DB_USER="aiwb_user"
-AIWB_DB_PASSWORD="your_aiwb_password"
+   ```bash
+   export POSTGRES_HOST=your-db-host       # e.g. host.docker.internal
+   export POSTGRES_PORT=5432
 
-KEYCLOAK_DB_NAME="keycloak"
-KEYCLOAK_DB_USER="keycloak"
-KEYCLOAK_DB_PASSWORD="your_keycloak_password"
-```
+   export AIWB_DB_NAME=aiwb
+   export AIWB_DB_USER=aiwb_user
+   export AIWB_DB_PASSWORD=your_aiwb_password
 
-## Step 3: Remove in-cluster CNPG clusters
+   export KEYCLOAK_DB_NAME=keycloak
+   export KEYCLOAK_DB_USER=keycloak
+   export KEYCLOAK_DB_PASSWORD=your_keycloak_password
+   ```
 
-> **WARNING — DATA LOSS**: This step permanently deletes the in-cluster PostgreSQL clusters and all data stored in them. Back up any data you need before proceeding.
+2. Run pluggable.sh (which sets `PLUGGABLE_DB=true` and calls
+   `install_base.sh`):
 
-```bash
-kubectl delete cluster -n aiwb aiwb-infra-cnpg-cnpg --ignore-not-found
-kubectl delete cluster -n keycloak keycloak-cnpg --ignore-not-found
-```
+   ```bash
+   ./scripts/pluggable.sh <DOMAIN>
+   ```
 
-Wait for the database pods to terminate:
+## What install_base.sh does in PLUGGABLE_DB=true mode
 
-```bash
-kubectl wait --for=delete pod \
-  -l "cnpg.io/cluster=aiwb-infra-cnpg-cnpg" \
-  -n aiwb \
-  --timeout=120s 2>/dev/null || true
+- Skips installing the cnpg-operator
+- Skips the CNPG `Cluster` CRs in the AIWB and Keycloak charts (renders the
+  charts with `cnpg.enabled=false`)
+- Skips applying `secrets/secrets-aiwb-cnpg.yaml` (the placeholder CNPG
+  superuser/user Secrets are not created)
+- Creates the user Secrets that AIWB and Keycloak read at startup, from
+  `${AIWB_DB_USER}` / `${AIWB_DB_PASSWORD}` and `${KEYCLOAK_DB_USER}` /
+  `${KEYCLOAK_DB_PASSWORD}`
+- Renders the AIWB and Keycloak charts with `--set postgresql.host`,
+  `postgresql.port`, `postgresql.dbName`, and `postgresql.userSecretName`
+  pointing at the external server
 
-kubectl wait --for=delete pod \
-  -l "cnpg.io/cluster=keycloak-cnpg" \
-  -n keycloak \
-  --timeout=120s 2>/dev/null || true
-```
-
-## Step 4: Update Kubernetes secrets
-
-Kubernetes secrets store credentials as base64-encoded strings. Encode your credentials:
-
-```bash
-AIWB_USER_B64=$(echo -n "$AIWB_DB_USER" | base64 -w 0)
-AIWB_PASS_B64=$(echo -n "$AIWB_DB_PASSWORD" | base64 -w 0)
-KEYCLOAK_USER_B64=$(echo -n "$KEYCLOAK_DB_USER" | base64 -w 0)
-KEYCLOAK_PASS_B64=$(echo -n "$KEYCLOAK_DB_PASSWORD" | base64 -w 0)
-```
-
-> **macOS**: Use `base64` without the `-w 0` flag.
-
-### Update AIWB secret
-
-```bash
-kubectl patch secret aiwb-cnpg-user -n aiwb --type='json' -p="[
-  {\"op\": \"replace\", \"path\": \"/data/username\", \"value\": \"${AIWB_USER_B64}\"},
-  {\"op\": \"replace\", \"path\": \"/data/password\", \"value\": \"${AIWB_PASS_B64}\"}
-]"
-```
-
-### Update Keycloak secret
-
-```bash
-kubectl patch secret keycloak-cnpg-user -n keycloak --type='json' -p="[
-  {\"op\": \"replace\", \"path\": \"/data/username\", \"value\": \"${KEYCLOAK_USER_B64}\"},
-  {\"op\": \"replace\", \"path\": \"/data/password\", \"value\": \"${KEYCLOAK_PASS_B64}\"}
-]"
-```
-
-## Step 5: Update AIWB deployment
-
-### Set database environment variables
-
-```bash
-kubectl set env deployment/aiwb-api -n aiwb \
-  DATABASE_HOST="${POSTGRES_HOST}" \
-  DATABASE_PORT="${POSTGRES_PORT}" \
-  DATABASE_NAME="${AIWB_DB_NAME}" \
-  DATABASE_USER="${AIWB_DB_USER}"
-```
-
-### Patch the `wait-for-db` init container
-
-The `wait-for-db` init container polls the database host until PostgreSQL is accepting connections. Update it to point to your external host:
-
-```bash
-kubectl patch deployment aiwb-api -n aiwb --type='json' -p="[
-  {
-    \"op\": \"replace\",
-    \"path\": \"/spec/template/spec/initContainers/0/command/2\",
-    \"value\": \"until pg_isready -h \\\"${POSTGRES_HOST}\\\" -p ${POSTGRES_PORT} -U ${AIWB_DB_USER}; do\\n  echo \\\"Waiting for database...\\\"\\n  sleep 2\\ndone\\necho \\\"Database is ready!\\\"\\n\"
-  }
-]"
-```
-
-### Patch the `liquibase-migrate` init container
-
-The `liquibase-migrate` init container runs schema migrations. Update its JDBC connection URL:
-
-```bash
-kubectl patch deployment aiwb-api -n aiwb --type='json' -p="[
-  {
-    \"op\": \"replace\",
-    \"path\": \"/spec/template/spec/initContainers/2/command/1\",
-    \"value\": \"--url=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${AIWB_DB_NAME}\"
-  }
-]"
-```
-
-## Step 6: Update Keycloak deployment
-
-```bash
-kubectl set env deployment/keycloak -n keycloak \
-  KC_DB_URL_HOST="${POSTGRES_HOST}" \
-  KC_DB_URL_PORT="${POSTGRES_PORT}" \
-  KC_DB_URL_DATABASE="${KEYCLOAK_DB_NAME}"
-```
-
-## Step 7: Restart deployments and wait for rollouts
-
-Apply all changes by restarting both deployments:
-
-```bash
-kubectl rollout restart deployment/aiwb-api -n aiwb
-kubectl rollout restart deployment/keycloak -n keycloak
-```
-
-Wait for the rollouts to complete (timeout 5 minutes each):
-
-```bash
-kubectl rollout status deployment/aiwb-api -n aiwb --timeout=300s
-kubectl rollout status deployment/keycloak -n keycloak --timeout=300s
-```
-
-## Step 8: Verify the configuration
-
-### Check pod status
+## Verify
 
 ```bash
 kubectl get pods -n aiwb
 kubectl get pods -n keycloak
-```
 
-All pods should reach `Running` state.
-
-### Confirm environment variables
-
-```bash
-# AIWB
-kubectl get deployment aiwb-api -n aiwb \
-  -o jsonpath='{.spec.template.spec.containers[0].env}' | jq
-
-# Keycloak
-kubectl get deployment keycloak -n keycloak \
-  -o jsonpath='{.spec.template.spec.containers[0].env}' | jq
-```
-
-### Confirm secrets
-
-```bash
-kubectl get secret aiwb-cnpg-user -n aiwb \
-  -o jsonpath='{.data.username}' | base64 -d
-
-kubectl get secret keycloak-cnpg-user -n keycloak \
-  -o jsonpath='{.data.username}' | base64 -d
-```
-
-### Check init container logs
-
-```bash
-# Confirm database was reachable before pod started
+# Confirm AIWB read the right host
 kubectl logs -n aiwb deployment/aiwb-api -c wait-for-db
 
-# Confirm schema migrations ran successfully
-kubectl logs -n aiwb deployment/aiwb-api -c liquibase-migrate
-```
-
-### Test connectivity from outside Kubernetes
-
-```bash
-PGPASSWORD="$AIWB_DB_PASSWORD" psql -h "$POSTGRES_HOST" -U "$AIWB_DB_USER" -d "$AIWB_DB_NAME" -c "SELECT 1"
+# Test connectivity from outside the cluster
+PGPASSWORD="$AIWB_DB_PASSWORD"     psql -h "$POSTGRES_HOST" -U "$AIWB_DB_USER"     -d "$AIWB_DB_NAME"     -c "SELECT 1"
 PGPASSWORD="$KEYCLOAK_DB_PASSWORD" psql -h "$POSTGRES_HOST" -U "$KEYCLOAK_DB_USER" -d "$KEYCLOAK_DB_NAME" -c "SELECT 1"
 ```
 
+## Limitations
+
+- **No migration path**: `PLUGGABLE_DB=true` is for fresh installs. There is
+  no built-in flow to move data from a previous in-cluster CNPG Cluster to
+  an external Postgres.
+- **Single Postgres instance assumed**: AIWB and Keycloak both connect to
+  the same `${POSTGRES_HOST}:${POSTGRES_PORT}`. Use separate hosts/users for
+  isolation if required by your environment, but both databases must be
+  reachable on the same endpoint.
+- **No connection pooler default**: install_base.sh does not deploy PgBouncer
+  or similar — connect AIWB / Keycloak through your own pooler if the
+  external Postgres needs one.
+- **Cosmetic log noise**: AIWB's `wait-for-db` init container hardcodes
+  `pg_isready -U postgres` (see `EXTERNAL_FIXES.md`). The check still
+  succeeds against the external Postgres, but the pod log will print
+  `FATAL: role "postgres" does not exist` lines until the external host has
+  a `postgres` role or until the upstream chart is fixed.

--- a/docs/manual_helm_install/components/s3.md
+++ b/docs/manual_helm_install/components/s3.md
@@ -1,397 +1,83 @@
-# Pluggable Object Storage (S3-Compatible)
+# Pluggable Object Storage
 
-This guide describes how to replace the ClusterForge-managed in-cluster MinIO installation with your own external MinIO-compatible object storage.
-
-## Overview
-
-ClusterForge provisions your Kubernetes cluster with AIWB connected to an in-cluster MinIO tenant (`default-minio-tenant`) running in the `minio-tenant-default` namespace. This tenant is managed by the MinIO Operator and provides three buckets used by AIWB: `default-bucket`, `models`, and `datasets`.
-
-These instructions walk you through:
-
-1. Setting up your own external MinIO server with the required buckets
-2. Removing the in-cluster MinIO Tenant and all data stored in it
-3. Patching the Kubernetes secrets and deployments that ClusterForge created so that AIWB connects to your MinIO instead
-
-> **Important**: Removing the in-cluster MinIO Tenant permanently deletes all object storage data (datasets, models, uploaded files). Back up any data you need before proceeding.
+Cluster Forge can be installed against an external S3-compatible object
+storage instead of the in-cluster MinIO Operator + Tenant default. In this
+mode `install_base.sh` skips the MinIO Operator, Tenant, and Tenant config
+installs, creates the `minio-credentials` Secrets directly from environment
+variables, and installs an in-cluster redirect Service that points the
+in-cluster MinIO URL at the external endpoint.
 
 ## Prerequisites
 
-1. **MinIO server** (or any S3-compatible store) is installed and reachable from Kubernetes pods
-2. **mc (MinIO Client)** or equivalent is available for initial bucket setup
-3. **kubectl** is installed and configured to access your ClusterForge cluster
-4. **Network connectivity** between your Kubernetes cluster and your MinIO server
+- S3-compatible storage reachable from the cluster (MinIO, AWS S3, GCS via
+  S3 gateway, etc.)
+- Three buckets pre-created with the exact names AIWB and the workbench
+  expect:
+  - `default-bucket`
+  - `models`
+  - `datasets`
+- Access credentials with read/write/list permissions on those buckets
 
-## Step 1: Set up external MinIO
+## Install
 
-### Install MinIO
+1. Set environment variables:
 
-If you do not already have a running MinIO instance, install it locally:
+   ```bash
+   export MINIO_HOST=host.docker.internal       # external host
+   export MINIO_PORT=9999                       # external port
+   export MINIO_HOST_IP=192.168.127.254         # IP that backs the redirect
+                                                # Endpoints (Rancher Desktop)
+   export MINIO_ACCESS_KEY=<access-key>
+   export MINIO_SECRET_KEY=<secret-key>
+   export MINIO_BUCKET=default-bucket
+   ```
 
-```bash
-# Homebrew (macOS/Linux)
-brew install minio/stable/minio
+2. Run pluggable.sh (which sets `PLUGGABLE_S3=true` and calls
+   `install_base.sh`):
 
-# Start with a local data directory
-MINIO_ROOT_USER=examplepass MINIO_ROOT_PASSWORD=examplepass \
-  minio server ~/minio-data --console-address ":9001"
-```
+   ```bash
+   ./scripts/pluggable.sh <DOMAIN>
+   ```
 
-MinIO listens on port `9000` (API) and `9001` (console) by default.
+3. (Optional) Run `scripts/s3.sh` after install for verification.
 
-### Network access from Kubernetes pods
+## What install_base.sh does in PLUGGABLE_S3=true mode
 
-Kubernetes pods cannot connect to `localhost` on the host machine. Use `host.docker.internal` to reach the host from within containers:
+- Skips installing the MinIO Operator, Tenant, and Tenant config
+- Skips applying `secrets/secrets-aiwb-minio.yaml` (the placeholder
+  `minio-credentials` and `default-user` Secrets are not created)
+- Creates `minio-credentials` Secrets in the `aiwb` and `workbench`
+  namespaces from `${MINIO_ACCESS_KEY}` / `${MINIO_SECRET_KEY}`
+- Creates an in-cluster redirect Service
+  `minio.minio-tenant-default.svc.cluster.local` whose Endpoints point to
+  `${MINIO_HOST_IP}:${MINIO_PORT}` (used by aim-performance and any other
+  in-cluster consumer that hardcodes the in-cluster MinIO URL — see
+  `EXTERNAL_FIXES.md`)
+- Renders the AIWB chart with `--set minio.url=http://${MINIO_HOST}:${MINIO_PORT}`
+  and `--set minio.bucket=${MINIO_BUCKET}` so AIWB talks to the external
+  endpoint directly
 
-```bash
-MINIO_HOST="host.docker.internal"
-MINIO_PORT="9000"
-```
-
-This hostname is supported by Docker Desktop (Mac/Windows) and Rancher Desktop. For Minikube or Kind, use the host's IP address instead:
-
-```bash
-# Find WSL/host IP
-ip addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'
-```
-
-> **Note**: WSL IP addresses can change after a reboot. Prefer `host.docker.internal` when available.
-
-**Windows Firewall (WSL + Rancher Desktop / Docker Desktop):** If MinIO runs inside WSL and Kubernetes runs on Windows, allow port 9000 through Windows Firewall. Run in PowerShell as Administrator:
-
-```powershell
-New-NetFirewallRule -DisplayName "WSL MinIO" -Direction Inbound -LocalPort 9000 -Protocol TCP -Action Allow
-```
-
-### Create required buckets
-
-AIWB requires three buckets. Create them using the MinIO Client (`mc`):
-
-```bash
-# Add your MinIO instance as an alias
-mc alias set local http://host.docker.internal:9000 examplepass examplepass
-
-# Create the required buckets
-mc mb local/default-bucket
-mc mb local/models
-mc mb local/datasets
-```
-
-Verify the buckets exist:
+## Verify
 
 ```bash
-mc ls local
+./scripts/s3.sh
 ```
 
-## Step 2: Set your configuration variables
-
-Set these shell variables before running the kubectl commands below.
-
-```bash
-MINIO_HOST="host.docker.internal"   # hostname or IP reachable from Kubernetes pods
-MINIO_PORT="9000"
-MINIO_ACCESS_KEY="examplepass"
-MINIO_SECRET_KEY="examplepass"
-MINIO_BUCKET="default-bucket"
-```
-
-## Step 3: Remove the in-cluster MinIO Tenant
-
-> **WARNING — DATA LOSS**: This step permanently deletes all object storage data in the in-cluster MinIO. Back up any datasets, models, or uploaded files before proceeding.
-
-### Remove the MinIO CronJob and Jobs
-
-Delete the `mc-user-create-cronjob` CronJob and any existing Jobs first. This prevents the MinIO Operator from spawning new pods after the Tenant is deleted:
-
-```bash
-kubectl delete cronjob mc-user-create-cronjob \
-  -n minio-tenant-default \
-  --ignore-not-found
-
-kubectl delete jobs --all \
-  -n minio-tenant-default \
-  --ignore-not-found
-```
-
-Wait for any CronJob-spawned pods to finish terminating:
-
-```bash
-kubectl wait --for=delete pod \
-  -l "batch.kubernetes.io/controller-uid" \
-  -n minio-tenant-default \
-  --timeout=60s 2>/dev/null || true
-```
-
-### Delete the MinIO Tenant
-
-Delete the MinIO Tenant custom resource. The MinIO Operator will tear down the associated StatefulSet and pods:
-
-```bash
-kubectl delete tenant.minio.min.io default-minio-tenant \
-  -n minio-tenant-default \
-  --ignore-not-found
-```
-
-Wait for all MinIO pods to terminate:
-
-```bash
-kubectl wait --for=delete pod \
-  -l app=minio \
-  -n minio-tenant-default \
-  --timeout=180s
-```
-
-Confirm no MinIO pods remain:
-
-```bash
-kubectl get pods -n minio-tenant-default
-```
-
-## Step 4: Create an in-cluster redirect for legacy consumers
-
-The AIWB API deployment is reconfigured directly via environment variables in Step 6, but several other in-cluster code paths address MinIO via the in-cluster DNS name `http://minio.minio-tenant-default.svc.cluster.local`. Steps 5–7 do not reconfigure those code paths. To keep them working, create a `Service` and a manually-managed `Endpoints` resource in the `minio-tenant-default` namespace that forwards in-cluster traffic to your external MinIO host. Skipping this step will break the flows listed below.
-
-### What breaks without this redirect
-
-AIWB renders the `aim-performance` workload chart (workspaces, model deployments, fine-tuning jobs) on demand. That chart ships with `BUCKET_STORAGE_HOST: http://minio.minio-tenant-default.svc.cluster.local:80` baked in as a default and injects it as an env var on every workload pod. Workspace startup paths (`mc alias set`, `boto3` clients, in-pod scripts) read it directly. Without the redirect, every newly spawned workspace, model deployment, and fine-tuning job fails to reach object storage — typically surfacing as `connection refused` in pod logs and a failed workload status in the AIWB UI.
-
-`aiwb-api` itself is not affected — it is reconfigured directly via env vars in Step 6 and does not depend on this redirect.
-
-### Find the host IP
-
-Kubernetes `Endpoints` require a literal IP address — hostnames such as `host.docker.internal` are not accepted in the `addresses` field. Look up the IP that pods use to reach the host:
-
-| Engine | Default host IP |
-|---|---|
-| Rancher Desktop | `192.168.127.254` |
-| Docker Desktop | resolve `host.docker.internal` from inside a pod |
-| kind / minikube | host IP — see your engine's networking docs |
-
-```bash
-MINIO_HOST_IP="192.168.127.254"   # adjust for your engine
-```
-
-### Create the redirect
-
-```bash
-kubectl create namespace minio-tenant-default --dry-run=client -o yaml | kubectl apply -f -
-
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: minio
-  namespace: minio-tenant-default
-spec:
-  ports:
-  - name: http-minio
-    port: 80
-    targetPort: ${MINIO_PORT}
-    protocol: TCP
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: minio
-  namespace: minio-tenant-default
-subsets:
-- addresses:
-  - ip: ${MINIO_HOST_IP}
-  ports:
-  - name: http-minio
-    port: ${MINIO_PORT}
-    protocol: TCP
-EOF
-```
-
-The Service listens on port `80`, so consumers using the default in-cluster URL (`http://minio.minio-tenant-default.svc.cluster.local`) reach your external MinIO without any client-side change.
-
-### Verify the redirect
-
-Run an in-cluster curl against the in-cluster URL — it should return `200`:
-
-```bash
-kubectl run minio-check --rm -i --restart=Never --quiet \
-  --image=curlimages/curl:8.10.1 \
-  -- curl -s -o /dev/null -w '%{http_code}\n' \
-     http://minio.minio-tenant-default.svc.cluster.local/minio/health/live
-```
-
-If you get a non-`200` response, the most common causes are an incorrect `MINIO_HOST_IP`, the host firewall blocking pod-to-host traffic on `${MINIO_PORT}`, or MinIO bound to `127.0.0.1` instead of `0.0.0.0`.
-
-## Step 5: Update Kubernetes secrets
-
-Kubernetes secrets store credentials as base64-encoded strings. Encode your credentials:
-
-```bash
-ACCESS_KEY_B64=$(echo -n "$MINIO_ACCESS_KEY" | base64 -w 0)
-SECRET_KEY_B64=$(echo -n "$MINIO_SECRET_KEY" | base64 -w 0)
-```
-
-> **macOS**: Use `base64` without the `-w 0` flag.
-
-### Update AIWB credentials
-
-```bash
-kubectl patch secret minio-credentials -n aiwb --type='json' -p="[
-  {\"op\": \"replace\", \"path\": \"/data/minio-access-key\", \"value\": \"${ACCESS_KEY_B64}\"},
-  {\"op\": \"replace\", \"path\": \"/data/minio-secret-key\", \"value\": \"${SECRET_KEY_B64}\"}
-]"
-```
-
-### Update workbench credentials
-
-Workspace pods (notebooks, terminals) read MinIO credentials from the `workbench` namespace:
-
-```bash
-kubectl patch secret minio-credentials -n workbench --type='json' -p="[
-  {\"op\": \"replace\", \"path\": \"/data/minio-access-key\", \"value\": \"${ACCESS_KEY_B64}\"},
-  {\"op\": \"replace\", \"path\": \"/data/minio-secret-key\", \"value\": \"${SECRET_KEY_B64}\"}
-]"
-```
-
-## Step 6: Update the AIWB deployment
-
-The AIWB API deployment has the MinIO endpoint baked in as environment variables. Override them to point to your external server:
-
-```bash
-kubectl set env deployment/aiwb-api -n aiwb \
-  MINIO_URL="http://${MINIO_HOST}:${MINIO_PORT}" \
-  MINIO_BUCKET="${MINIO_BUCKET}"
-```
-
-## Step 7: Restart the AIWB deployment
-
-Apply all changes by restarting the deployment:
-
-```bash
-kubectl rollout restart deployment/aiwb-api -n aiwb
-```
-
-Wait for the rollout to complete (timeout 5 minutes):
-
-```bash
-kubectl rollout status deployment/aiwb-api -n aiwb --timeout=300s
-```
-
-## Step 8: Verify the configuration
-
-### Check pod status
-
-```bash
-kubectl get pods -n aiwb
-```
-
-All pods should reach `Running` state.
-
-### Confirm environment variables
-
-```bash
-kubectl get deployment aiwb-api -n aiwb \
-  -o jsonpath='{.spec.template.spec.containers[0].env}' | jq \
-  '.[] | select(.name | test("MINIO"))'
-```
-
-Expected output shows `MINIO_URL` pointing to your external host.
-
-### Confirm secrets
-
-```bash
-kubectl get secret minio-credentials -n aiwb \
-  -o jsonpath='{.data.minio-access-key}' | base64 -d
-
-kubectl get secret minio-credentials -n workbench \
-  -o jsonpath='{.data.minio-access-key}' | base64 -d
-```
-
-### Check AIWB logs for connectivity
-
-```bash
-kubectl logs -n aiwb deployment/aiwb-api -c aiwb-api | grep -i minio
-```
-
-### Test MinIO connectivity from a pod
-
-```bash
-kubectl exec -n aiwb deployment/aiwb-api -c aiwb-api -- \
-  sh -c 'curl -s -o /dev/null -w "%{http_code}" $MINIO_URL/minio/health/live'
-```
-
-Expected response: `200`
-
-## Troubleshooting
-
-### AIWB cannot connect to MinIO
-
-**Check reachability from a pod:**
-
-```bash
-kubectl exec -n aiwb deployment/aiwb-api -c aiwb-api -- \
-  sh -c "curl -v http://${MINIO_HOST}:${MINIO_PORT}/minio/health/live"
-```
-
-**Verify `MINIO_URL` is set correctly:**
-
-```bash
-kubectl get deployment aiwb-api -n aiwb \
-  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="MINIO_URL")].value}'
-```
-
-**Verify MinIO is listening on all interfaces:**
-
-```bash
-# On the host running MinIO
-netstat -tlnp | grep 9000
-# Should show 0.0.0.0:9000 or :::9000, not 127.0.0.1:9000
-```
-
-### Authentication errors
-
-Verify the credentials stored in the secret match your MinIO server:
-
-```bash
-STORED_KEY=$(kubectl get secret minio-credentials -n aiwb \
-  -o jsonpath='{.data.minio-access-key}' | base64 -d)
-
-mc alias set test-local "http://${MINIO_HOST}:${MINIO_PORT}" \
-  "$STORED_KEY" "$(kubectl get secret minio-credentials -n aiwb \
-  -o jsonpath='{.data.minio-secret-key}' | base64 -d)"
-
-mc ls test-local
-```
-
-### Buckets not found
-
-Ensure all required buckets exist in your external MinIO:
-
-```bash
-mc alias set local http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY}
-mc ls local
-```
-
-Create any missing buckets:
-
-```bash
-mc mb local/default-bucket
-mc mb local/models
-mc mb local/datasets
-```
-
-## Security recommendations
-
-### Strong credentials
-
-Generate random credentials instead of using placeholders:
-
-```bash
-MINIO_ACCESS_KEY=$(openssl rand -hex 16)
-MINIO_SECRET_KEY=$(openssl rand -base64 32)
-```
-
-### Restrict network access
-
-Configure MinIO to only accept connections from your Kubernetes cluster's IP range. In MinIO, this is typically done at the network/firewall level rather than in MinIO configuration itself.
-
-### Enable TLS
-
-For production, run MinIO with TLS and use `https://` in `MINIO_URL`. Ensure the certificate is trusted by the pods (add it to the pod's trust store or use a publicly trusted CA).
-
+This non-destructive script prints AIWB's `MINIO_URL` / `MINIO_BUCKET`,
+the access keys stored in the `aiwb` and `workbench` `minio-credentials`
+Secrets, the redirect Endpoints, and runs a short-lived curl pod against
+`http://minio.minio-tenant-default.svc.cluster.local/minio/health/live` to
+confirm the redirect resolves to a healthy external MinIO.
+
+## Limitations
+
+- **No migration path**: `PLUGGABLE_S3=true` is for fresh installs. There
+  is no built-in flow to move objects from a previous in-cluster MinIO
+  Tenant to external storage.
+- **No multi-bucket overrides**: only `MINIO_BUCKET` (default bucket) is
+  configurable via env. The `models` and `datasets` buckets must exist with
+  those exact names in the external storage.
+- **In-cluster URL redirect required**: aim-performance workloads hardcode
+  the in-cluster MinIO URL via `BUCKET_STORAGE_HOST`. Until that is
+  parametrized upstream (see `EXTERNAL_FIXES.md`), the redirect Service is
+  necessary even in `PLUGGABLE_S3=true` mode.

--- a/docs/manual_helm_install/scripts/install_base.sh
+++ b/docs/manual_helm_install/scripts/install_base.sh
@@ -58,6 +58,10 @@ MINIO_PORT="${MINIO_PORT:-9999}"
 # Override with MINIO_HOST_IP=<ip> for other engines (kind, minikube, etc.).
 MINIO_HOST_IP="${MINIO_HOST_IP:-192.168.127.254}"
 MINIO_BUCKET="${MINIO_BUCKET:-default-bucket}"
+# Credentials for the external MinIO. Defaults match s3_minio_container.sh so a
+# stock dev workflow works out of the box; override for any non-dev deployment.
+MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-examplepass}"
+MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-examplepass}"
 METALLB_IP_RANGE="${METALLB_IP_RANGE:-192.168.127.240-192.168.127.250}"
 
 # Derive protocol-aware URL bases from DOMAIN.

--- a/docs/manual_helm_install/scripts/install_base.sh
+++ b/docs/manual_helm_install/scripts/install_base.sh
@@ -45,13 +45,18 @@ KEYCLOAK_DB_PASSWORD="${KEYCLOAK_DB_PASSWORD:-examplepassword}"
 AIWB_DB_SECRET_NAME="aiwb-db-user"
 KEYCLOAK_DB_SECRET_NAME="keycloak-db-user"
 
-# External MinIO config — used only when PLUGGABLE_S3=true to override the
-# AIWB chart's MinIO endpoint. The in-cluster redirect Service that backs the
-# in-cluster MinIO URL is set up separately by scripts/s3.sh.
+# External MinIO config — used only when PLUGGABLE_S3=true. AIWB is pointed
+# at the external endpoint via --set minio.url / minio.bucket below, and an
+# in-cluster redirect Service is created so that consumers that hardcode the
+# in-cluster MinIO URL (e.g. aim-performance's BUCKET_STORAGE_HOST) reach the
+# external storage transparently.
 MINIO_HOST="${MINIO_HOST:-host.docker.internal}"
 # Host port external MinIO publishes its S3 API on. Default 9999 matches the
 # minio-byo container layout used in this dev workflow (container :9000 → host :9999).
 MINIO_PORT="${MINIO_PORT:-9999}"
+# IP that backs the redirect Endpoints. Defaults to the Rancher Desktop host IP.
+# Override with MINIO_HOST_IP=<ip> for other engines (kind, minikube, etc.).
+MINIO_HOST_IP="${MINIO_HOST_IP:-192.168.127.254}"
 MINIO_BUCKET="${MINIO_BUCKET:-default-bucket}"
 METALLB_IP_RANGE="${METALLB_IP_RANGE:-192.168.127.240-192.168.127.250}"
 
@@ -592,8 +597,22 @@ done
 
 # Install AIWB secrets from local file
 echo "  📦 Installing AIWB secrets..."
-# Apply AIWB standalone secrets (all placeholder credentials)
+# Apply AIWB standalone secrets (always required, regardless of pluggable mode)
 kubectl apply -f "${SCRIPT_DIR}/../secrets/secrets-aiwb.yaml"
+
+# CNPG-related secrets: only needed when in-cluster Postgres (CNPG) is installed.
+# In PLUGGABLE_DB=true mode the env-based block below creates the user secret
+# pointing to the external Postgres host instead.
+if [[ "${PLUGGABLE_DB}" != true ]]; then
+  kubectl apply -f "${SCRIPT_DIR}/../secrets/secrets-aiwb-cnpg.yaml"
+fi
+
+# MinIO-related secrets: only needed when in-cluster MinIO Tenant is installed.
+# In PLUGGABLE_S3=true mode the env-based block below creates minio-credentials
+# in aiwb and workbench namespaces from MINIO_ACCESS_KEY / MINIO_SECRET_KEY.
+if [[ "${PLUGGABLE_S3}" != true ]]; then
+  kubectl apply -f "${SCRIPT_DIR}/../secrets/secrets-aiwb-minio.yaml"
+fi
 
 # Apply secrets with hardcoded values (overrides secrets-aiwb.yaml where needed)
 kubectl apply -f "${SCRIPT_DIR}/../secrets/secrets-override-hardcoded.yaml"
@@ -616,6 +635,19 @@ if [[ "${PLUGGABLE_DB}" == true ]]; then
     --from-literal=password="${KEYCLOAK_DB_PASSWORD}" \
     --dry-run=client -o yaml | kubectl apply -f -
   echo "  ✅ Pluggable database credentials secrets created"
+fi
+
+# Pluggable S3: create minio-credentials secrets that AIWB and workbench pods
+# read at startup, populated from MINIO_ACCESS_KEY / MINIO_SECRET_KEY env vars.
+if [[ "${PLUGGABLE_S3}" == true ]]; then
+  echo "  📦 Creating pluggable S3 credentials secrets..."
+  for ns in aiwb workbench; do
+    kubectl create secret generic minio-credentials -n "${ns}" \
+      --from-literal=minio-access-key="${MINIO_ACCESS_KEY}" \
+      --from-literal=minio-secret-key="${MINIO_SECRET_KEY}" \
+      --dry-run=client -o yaml | kubectl apply -f -
+  done
+  echo "  ✅ Pluggable S3 credentials secrets created"
 fi
 
 # ============================================================================
@@ -813,9 +845,46 @@ if [[ "${PLUGGABLE_S3}" != true ]]; then
   echo ""
 else
   echo "PLUGGABLE_S3=true => Skipping in-cluster MinIO Operator, Tenant and configuration."
-  echo "Run scripts/s3.sh after this script completes — it creates the in-cluster"
-  echo "redirect Service that forwards the in-cluster MinIO URL to ${MINIO_HOST}:${MINIO_PORT}"
-  echo "and patches the AIWB credentials."
+  echo ""
+
+  # Redirect Service: forwards http://minio.minio-tenant-default.svc.cluster.local:80
+  # to ${MINIO_HOST_IP}:${MINIO_PORT} so consumers that hardcode the in-cluster
+  # MinIO URL (e.g. aim-performance via BUCKET_STORAGE_HOST) reach the external
+  # storage transparently. AIWB itself talks to the external endpoint directly
+  # via --set minio.url below and does not depend on this redirect.
+  # See docs/manual_helm_install/EXTERNAL_FIXES.md "aim-performance hardcoded
+  # BUCKET_STORAGE_HOST" for why this workaround is currently needed.
+  echo "  📦 Creating in-cluster redirect Service for external MinIO..."
+  echo "     target: ${MINIO_HOST_IP}:${MINIO_PORT}"
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: minio-tenant-default
+spec:
+  ports:
+  - name: http-minio
+    port: 80
+    targetPort: ${MINIO_PORT}
+    protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: minio
+  namespace: minio-tenant-default
+subsets:
+- addresses:
+  - ip: ${MINIO_HOST_IP}
+  ports:
+  - name: http-minio
+    port: ${MINIO_PORT}
+    protocol: TCP
+EOF
+  echo "  ✅ Redirect Service ready"
+  echo ""
+  echo "Run scripts/s3.sh after this script completes for post-install verification."
   echo ""
 fi
 

--- a/docs/manual_helm_install/scripts/install_base.sh
+++ b/docs/manual_helm_install/scripts/install_base.sh
@@ -380,22 +380,25 @@ kubectl apply -f ${SOURCES_DIR}/gateway-api/v1.3.0/experimental-install.yaml --s
 # Install kgateway as the Gateway API implementation
 kubectl create namespace kgateway-system --dry-run=client -o yaml | kubectl apply -f -
 helm template kgateway-crds ${SOURCES_DIR}/kgateway-crds/v2.1.0-main --namespace kgateway-system | kubectl apply --server-side -f -
-helm template kgateway ${SOURCES_DIR}/kgateway/v2.1.0-main --namespace kgateway-system --set service.type=LoadBalancer | kubectl apply --server-side -f -
+helm template kgateway ${SOURCES_DIR}/kgateway/v2.1.0-main --namespace kgateway-system --set service.type=LoadBalancer | kubectl apply --server-side --force-conflicts -f -
 
 # Patch: kgateway v2.1.0-main ClusterRole is missing tokenreviews, which the xDS server
 # requires to validate JWT tokens from Envoy proxy. Without it, Envoy cannot connect to
 # the xDS control plane and the gateway serves no routes.
-kubectl patch clusterrole kgateway-kgateway-system --type=json -p='[
-  {
-    "op": "add",
-    "path": "/rules/-",
-    "value": {
-      "apiGroups": ["authentication.k8s.io"],
-      "resources": ["tokenreviews"],
-      "verbs": ["create"]
+if ! kubectl get clusterrole kgateway-kgateway-system -o json \
+    | jq -e '.rules[] | select(.resources | index("tokenreviews")) | select(.apiGroups | index("authentication.k8s.io")) | select(.verbs | index("create"))' >/dev/null; then
+  kubectl patch clusterrole kgateway-kgateway-system --type=json -p='[
+    {
+      "op": "add",
+      "path": "/rules/-",
+      "value": {
+        "apiGroups": ["authentication.k8s.io"],
+        "resources": ["tokenreviews"],
+        "verbs": ["create"]
+      }
     }
-  }
-]'
+  ]'
+fi
 
 # Wait for kgateway to be ready
 echo "⏳ Waiting for kgateway to be ready..."

--- a/docs/manual_helm_install/scripts/install_base.sh
+++ b/docs/manual_helm_install/scripts/install_base.sh
@@ -856,6 +856,13 @@ else
   # BUCKET_STORAGE_HOST" for why this workaround is currently needed.
   echo "  📦 Creating in-cluster redirect Service for external MinIO..."
   echo "     target: ${MINIO_HOST_IP}:${MINIO_PORT}"
+  # Remove any pre-existing minio Service / Endpoints first. If a previous
+  # install ran in PLUGGABLE_S3=false mode, the MinIO Operator created a
+  # selector-backed Service named "minio" — applying a selectorless Service
+  # on top of it produces server-side-apply conflicts. The delete is a no-op
+  # on fresh clusters thanks to --ignore-not-found.
+  kubectl delete service minio   -n minio-tenant-default --ignore-not-found
+  kubectl delete endpoints minio -n minio-tenant-default --ignore-not-found
   kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Service

--- a/docs/manual_helm_install/scripts/pluggable.sh
+++ b/docs/manual_helm_install/scripts/pluggable.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 
-export PLUGGABLE_DB=false
-export PLUGGABLE_S3=false
-export PLUGGABLE_GW=false
+export PLUGGABLE_DB="${PLUGGABLE_DB:-false}"
+export PLUGGABLE_S3="${PLUGGABLE_S3:-false}"
+export PLUGGABLE_GW="${PLUGGABLE_GW:-false}"
 
 "${SCRIPT_DIR}/install_base.sh" "$@"
 

--- a/docs/manual_helm_install/scripts/s3.sh
+++ b/docs/manual_helm_install/scripts/s3.sh
@@ -1,31 +1,34 @@
 #!/bin/bash
 
-# Pluggable S3 Override Script — Proof-of-Concept
-# Removes the in-cluster MinIO Tenant and patches Kubernetes resources so that
-# AIWB connects to an external MinIO-compatible object storage instead.
+# Pluggable S3 — Post-install verification script.
+# Run this after install_base.sh has completed in PLUGGABLE_S3=true mode to
+# confirm that:
+#   1. AIWB is configured to talk to the external MinIO endpoint
+#   2. minio-credentials Secrets in aiwb / workbench namespaces match the
+#      external MinIO credentials
+#   3. The in-cluster redirect Service resolves to the external MinIO and the
+#      external MinIO answers /minio/health/live with HTTP 200
+#
+# This script is non-destructive — it only reads cluster state and runs a
+# short-lived curl pod against the redirect URL. It does NOT delete the
+# in-cluster MinIO Tenant, patch Secrets, or restart Deployments. The
+# install_base.sh PLUGGABLE_S3 branch is responsible for setting up all of
+# the resources this script verifies.
 
 set -euo pipefail
 
 # ============================================================================
-# Configuration
+# Configuration — must match the values used when running install_base.sh
 # ============================================================================
 
 MINIO_HOST="${MINIO_HOST:-host.docker.internal}"
-# Host port external MinIO publishes its S3 API on. Default 19000 matches the
-# minio-byo container layout used in this dev workflow (container :9000 → host :19000).
-MINIO_PORT="${MINIO_PORT:-19000}"
-# IP that backs the redirect Endpoints. Defaults to the Rancher Desktop host IP.
-# Override with MINIO_HOST_IP=<ip> for other engines (kind, minikube, etc).
-MINIO_HOST_IP="${MINIO_HOST_IP:-192.168.127.254}"
-MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-examplepass}"
-MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-examplepass}"
+MINIO_PORT="${MINIO_PORT:-9999}"
 MINIO_BUCKET="${MINIO_BUCKET:-default-bucket}"
 KUBE_CONTEXT="${KUBE_CONTEXT:-rancher-desktop}"
 
 AIWB_NAMESPACE="aiwb"
 WORKBENCH_NAMESPACE="workbench"
 MINIO_NAMESPACE="minio-tenant-default"
-MINIO_TENANT_NAME="default-minio-tenant"
 
 # ============================================================================
 # Helpers
@@ -35,8 +38,6 @@ log_info()    { echo "📦 $1"; }
 log_success() { echo "✅ $1"; }
 log_warning() { echo "⚠️  $1"; }
 log_error()   { echo "❌ $1" >&2; }
-
-encode_base64() { echo -n "$1" | base64 -w 0; }
 
 check_kubectl() {
   if ! command -v kubectl >/dev/null 2>&1; then
@@ -65,7 +66,7 @@ check_context() {
 
 echo ""
 echo "=========================================================================="
-echo "  Pluggable S3 Override — External MinIO Configuration"
+echo "  Pluggable S3 — Post-install verification"
 echo "=========================================================================="
 echo "  External MinIO: http://${MINIO_HOST}:${MINIO_PORT}"
 echo "  Bucket:         ${MINIO_BUCKET}"
@@ -76,206 +77,11 @@ check_kubectl
 check_context
 
 # ============================================================================
-# WARNING: Destructive step — delete in-cluster MinIO Tenant
-# ============================================================================
-
-echo ""
-echo "=========================================================================="
-echo "⚠️  WARNING: DESTRUCTIVE OPERATION — DATA LOSS"
-echo "=========================================================================="
-echo "  This script will DELETE the in-cluster MinIO Tenant '${MINIO_TENANT_NAME}'"
-echo "  from namespace '${MINIO_NAMESPACE}' and ALL DATA stored in it."
-echo ""
-echo "  ALL object storage data (datasets, models, uploads) will be permanently"
-echo "  lost. This action CANNOT be undone."
-echo ""
-echo "  Before continuing, ensure:"
-echo "    1. All data in the in-cluster MinIO has been backed up or is not needed"
-echo "    2. External MinIO is running at ${MINIO_HOST}:${MINIO_PORT}"
-echo "    3. External MinIO has the required buckets: default-bucket, models, datasets"
-echo "    4. External MinIO credentials are: ${MINIO_ACCESS_KEY} / ${MINIO_SECRET_KEY}"
-echo "=========================================================================="
-echo ""
-read -r -p "Type 'yes' to confirm data loss and proceed: " confirm
-if [[ "${confirm}" != "yes" ]]; then
-  echo "Aborted."
-  exit 1
-fi
-echo ""
-
-# ============================================================================
-# Remove minio-tenant-config CronJob and Jobs first
-# (prevents new Error pods from spawning after the Tenant is deleted)
-# ============================================================================
-
-log_info "Deleting mc-user-create-cronjob and all associated Jobs..."
-kubectl delete cronjob mc-user-create-cronjob \
-  -n "${MINIO_NAMESPACE}" \
-  --ignore-not-found \
-  && log_success "CronJob deleted (or was not present)" \
-  || log_warning "CronJob deletion may have failed — continuing"
-
-kubectl delete jobs --all \
-  -n "${MINIO_NAMESPACE}" \
-  --ignore-not-found 2>/dev/null \
-  && log_success "Jobs deleted" \
-  || log_warning "Job deletion may have failed — continuing"
-
-# Wait for CronJob-spawned pods to finish terminating
-kubectl wait --for=delete pod \
-  -l "batch.kubernetes.io/controller-uid" \
-  -n "${MINIO_NAMESPACE}" \
-  --timeout=60s 2>/dev/null || true
-
-echo ""
-
-# ============================================================================
-# Remove in-cluster MinIO Tenant
-# ============================================================================
-
-log_info "Deleting in-cluster MinIO Tenant '${MINIO_TENANT_NAME}'..."
-kubectl delete tenant.minio.min.io "${MINIO_TENANT_NAME}" \
-  -n "${MINIO_NAMESPACE}" \
-  --ignore-not-found \
-  && log_success "MinIO Tenant deleted (or was not present)" \
-  || log_warning "MinIO Tenant deletion may have failed — continuing"
-
-echo "⏳ Waiting for MinIO pods to terminate..."
-kubectl wait --for=delete pod \
-  -l app=minio \
-  -n "${MINIO_NAMESPACE}" \
-  --timeout=180s 2>/dev/null \
-  && log_success "MinIO pods terminated" \
-  || log_warning "Timeout waiting for pod termination — continuing"
-
-echo ""
-
-# ============================================================================
-# Create redirect Service for in-cluster minio name → external host
-# ============================================================================
-# Forwards http://minio.minio-tenant-default.svc.cluster.local:80 to
-# ${MINIO_HOST}:${MINIO_PORT} so aim-performance workloads (and any other
-# in-cluster consumer that bakes in the in-cluster URL via env vars like
-# BUCKET_STORAGE_HOST) reach the external MinIO transparently.
-# aiwb-api itself is set directly to ${MINIO_HOST}:${MINIO_PORT} below and
-# does not depend on this redirect.
-#
-# DOC NOTE: The "default-user" secret in ${MINIO_NAMESPACE} (created by
-# install_base.sh from secrets-aiwb.yaml / secrets-override-hardcoded.yaml)
-# was consumed by the in-cluster MinIO Tenant which is now gone. It is left
-# in place harmlessly — nothing reads it after the Tenant is deleted.
-
-log_info "Creating in-cluster redirect Service for external MinIO..."
-
-# Ensure the namespace exists (s3.sh may run before in-cluster MinIO was ever installed)
-kubectl create namespace "${MINIO_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-
-log_info "Redirect target: ${MINIO_HOST_IP}:${MINIO_PORT} (override with MINIO_HOST_IP=<ip>)"
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: minio
-  namespace: ${MINIO_NAMESPACE}
-spec:
-  ports:
-  - name: http-minio
-    port: 80
-    targetPort: ${MINIO_PORT}
-    protocol: TCP
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: minio
-  namespace: ${MINIO_NAMESPACE}
-subsets:
-- addresses:
-  - ip: ${MINIO_HOST_IP}
-  ports:
-  - name: http-minio
-    port: ${MINIO_PORT}
-    protocol: TCP
-EOF
-log_success "In-cluster MinIO redirect Service ready"
-
-echo ""
-
-# ============================================================================
-# Patch Secrets
-# ============================================================================
-
-log_info "Encoding credentials..."
-ACCESS_KEY_B64=$(encode_base64 "${MINIO_ACCESS_KEY}")
-SECRET_KEY_B64=$(encode_base64 "${MINIO_SECRET_KEY}")
-
-log_info "Patching minio-credentials in namespace '${AIWB_NAMESPACE}'..."
-kubectl patch secret minio-credentials -n "${AIWB_NAMESPACE}" --type='json' -p="[
-  {\"op\": \"replace\", \"path\": \"/data/minio-access-key\", \"value\": \"${ACCESS_KEY_B64}\"},
-  {\"op\": \"replace\", \"path\": \"/data/minio-secret-key\", \"value\": \"${SECRET_KEY_B64}\"}
-]" && log_success "aiwb/minio-credentials updated" || log_warning "aiwb/minio-credentials patch may have failed"
-
-log_info "Patching minio-credentials in namespace '${WORKBENCH_NAMESPACE}'..."
-kubectl patch secret minio-credentials -n "${WORKBENCH_NAMESPACE}" --type='json' -p="[
-  {\"op\": \"replace\", \"path\": \"/data/minio-access-key\", \"value\": \"${ACCESS_KEY_B64}\"},
-  {\"op\": \"replace\", \"path\": \"/data/minio-secret-key\", \"value\": \"${SECRET_KEY_B64}\"}
-]" && log_success "workbench/minio-credentials updated" || log_warning "workbench/minio-credentials patch may have failed"
-
-# ============================================================================
-# Ensure workbench namespace has the project-id label AIWB requires
-# ============================================================================
-# aiwb-api rejects requests to a workbench namespace that lacks the
-# airm.silogen.ai/project-id label (see aiwb security.py: "is not a workbench
-# namespace (missing project-id label)"). The label is normally set by the
-# AIWB chart's templates/namespace.yaml during install_base.sh, but on partial
-# re-installs (e.g. when SSA conflicts with manually-set fields cause the
-# helm apply to abort) the label can end up missing on the existing namespace.
-# This step idempotently restores it: --overwrite=false preserves any existing
-# project-id, and adds a fresh UUID only when the label is absent.
-
-log_info "Ensuring workbench namespace has project-id label..."
-PROJECT_ID_LABEL="airm.silogen.ai/project-id"
-EXISTING_PROJECT_ID=$(kubectl get namespace "${WORKBENCH_NAMESPACE}" \
-  -o jsonpath="{.metadata.labels.${PROJECT_ID_LABEL//./\\.}}" 2>/dev/null || echo "")
-if [[ -n "${EXISTING_PROJECT_ID}" ]]; then
-  log_success "workbench namespace already has ${PROJECT_ID_LABEL}=${EXISTING_PROJECT_ID}"
-else
-  NEW_PROJECT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-  kubectl label namespace "${WORKBENCH_NAMESPACE}" \
-    "${PROJECT_ID_LABEL}=${NEW_PROJECT_ID}" --overwrite=false \
-    && log_success "workbench namespace labeled ${PROJECT_ID_LABEL}=${NEW_PROJECT_ID}" \
-    || log_warning "Failed to label workbench namespace"
-fi
-
-# ============================================================================
-# Patch AIWB Deployment
-# ============================================================================
-
-log_info "Updating AIWB deployment MINIO_URL and MINIO_BUCKET..."
-kubectl set env deployment/aiwb-api -n "${AIWB_NAMESPACE}" \
-  MINIO_URL="http://${MINIO_HOST}:${MINIO_PORT}" \
-  MINIO_BUCKET="${MINIO_BUCKET}" \
-  && log_success "AIWB deployment env vars updated" \
-  || log_warning "AIWB deployment env update may have failed"
-
-# ============================================================================
-# Restart and Wait
-# ============================================================================
-
-log_info "Restarting AIWB deployment..."
-kubectl rollout restart deployment/aiwb-api -n "${AIWB_NAMESPACE}" \
-  && log_success "AIWB deployment restarted" \
-  || log_warning "AIWB deployment restart may have failed"
-
-log_info "Waiting for AIWB rollout to complete..."
-kubectl rollout status deployment/aiwb-api -n "${AIWB_NAMESPACE}" --timeout=300s
-
-# ============================================================================
 # Verification
 # ============================================================================
 
 echo ""
-echo "Current AIWB MinIO configuration:"
+echo "AIWB MinIO configuration:"
 kubectl get deployment aiwb-api -n "${AIWB_NAMESPACE}" \
   -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="MINIO_URL")].value}' \
   2>/dev/null | xargs -I {} echo "  MINIO_URL:    {}"
@@ -284,9 +90,13 @@ kubectl get deployment aiwb-api -n "${AIWB_NAMESPACE}" \
   2>/dev/null | xargs -I {} echo "  MINIO_BUCKET: {}"
 
 echo ""
+echo "minio-credentials Secrets:"
 kubectl get secret minio-credentials -n "${AIWB_NAMESPACE}" \
   -o jsonpath='{.data.minio-access-key}' 2>/dev/null \
-  | base64 -d | xargs -I {} echo "  aiwb/minio-credentials access-key: {}"
+  | base64 -d | xargs -I {} echo "  ${AIWB_NAMESPACE}/minio-credentials access-key: {}"
+kubectl get secret minio-credentials -n "${WORKBENCH_NAMESPACE}" \
+  -o jsonpath='{.data.minio-access-key}' 2>/dev/null \
+  | base64 -d | xargs -I {} echo "  ${WORKBENCH_NAMESPACE}/minio-credentials access-key: {}"
 
 echo ""
 echo "Redirect Service:"
@@ -309,12 +119,6 @@ fi
 
 echo ""
 echo "=========================================================================="
-echo "PLUGGABLE S3 Override Complete"
+echo "Verification complete"
 echo "=========================================================================="
-echo ""
-echo "External MinIO: http://${MINIO_HOST}:${MINIO_PORT}"
-echo ""
-echo "Next steps:"
-echo "  kubectl get pods -n ${AIWB_NAMESPACE}"
-echo "  kubectl logs -n ${AIWB_NAMESPACE} deployment/aiwb-api -c aiwb-api | grep -i minio"
 echo ""

--- a/docs/manual_helm_install/scripts/s3_minio_container.sh
+++ b/docs/manual_helm_install/scripts/s3_minio_container.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # Sets up an external MinIO instance as a Docker container.
-# Run this BEFORE scripts/s3.sh to prepare the external object storage.
+# Run this BEFORE scripts/pluggable.sh to prepare the external object storage.
 #
-# After this script completes, run scripts/s3.sh with the printed environment variables.
+# After this script completes, run scripts/pluggable.sh with PLUGGABLE_S3=true
+# and the printed environment variables. Then optionally run scripts/s3.sh for
+# post-install verification.
 
 set -euo pipefail
 
@@ -140,13 +142,14 @@ echo "  From Kubernetes pods, use:  host.docker.internal:${MINIO_API_PORT}"
 echo "  (Supported on Rancher Desktop and Docker Desktop.)"
 echo "  On Minikube/Kind, use the host IP instead of host.docker.internal."
 echo ""
-echo "  Run scripts/s3.sh with:"
+echo "  Run scripts/pluggable.sh with:"
 echo ""
+echo "    PLUGGABLE_S3=true \\"
 echo "    MINIO_HOST=host.docker.internal \\"
 echo "    MINIO_PORT=${MINIO_API_PORT} \\"
 echo "    MINIO_ACCESS_KEY=${MINIO_ROOT_USER} \\"
 echo "    MINIO_SECRET_KEY=${MINIO_ROOT_PASSWORD} \\"
-echo "    ./pluggable/scripts/s3.sh"
+echo "    ./scripts/pluggable.sh <DOMAIN>"
 echo ""
 echo "  To stop the container:"
 echo "    docker stop ${CONTAINER_NAME}"

--- a/docs/manual_helm_install/secrets/secrets-aiwb-cnpg.yaml
+++ b/docs/manual_helm_install/secrets/secrets-aiwb-cnpg.yaml
@@ -1,0 +1,57 @@
+# AIWB Standalone CNPG Secrets
+# Secrets consumed by the in-cluster CloudNativePG Cluster resources for AIWB
+# and Keycloak. Only applied when PLUGGABLE_DB=false (i.e. install_base.sh
+# is creating in-cluster CNPG Clusters). In PLUGGABLE_DB=true mode these
+# Secrets are not used and install_base.sh creates env-based Secrets pointing
+# to the external Postgres host instead.
+#
+# All credentials use "placeholder" for development — replace with secure
+# values for production.
+
+---
+# aiwb/aiwb-cnpg-superuser
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aiwb-cnpg-superuser
+  namespace: aiwb
+type: Opaque
+stringData:
+  password: placeholder
+  username: placeholder
+
+---
+# aiwb/aiwb-cnpg-user
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aiwb-cnpg-user
+  namespace: aiwb
+type: Opaque
+stringData:
+  password: placeholder
+  username: aiwb_user
+
+---
+# keycloak/keycloak-cnpg-superuser
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-cnpg-superuser
+  namespace: keycloak
+type: Opaque
+stringData:
+  password: placeholder
+  username: placeholder
+
+---
+# keycloak/keycloak-cnpg-user
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-cnpg-user
+  namespace: keycloak
+type: Opaque
+stringData:
+  password: placeholder
+  username: keycloak

--- a/docs/manual_helm_install/secrets/secrets-aiwb-minio.yaml
+++ b/docs/manual_helm_install/secrets/secrets-aiwb-minio.yaml
@@ -1,0 +1,52 @@
+# AIWB Standalone MinIO Secrets
+# Secrets consumed by the in-cluster MinIO Operator + Tenant + Tenant config,
+# and by AIWB / workbench pods that talk to in-cluster MinIO. Only applied
+# when PLUGGABLE_S3=false. In PLUGGABLE_S3=true mode the in-cluster MinIO
+# Tenant is not installed; install_base.sh instead creates env-based
+# minio-credentials Secrets in the aiwb and workbench namespaces using
+# MINIO_ACCESS_KEY / MINIO_SECRET_KEY.
+#
+# All credentials use "placeholder" for development — replace with secure
+# values for production.
+
+---
+# aiwb/minio-credentials
+# MinIO credentials for AIWB to access object storage
+# Must match the MinIO tenant root credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: aiwb
+type: Opaque
+stringData:
+  minio-access-key: placeholder
+  minio-secret-key: placeholder
+
+---
+# workbench/minio-credentials
+# MinIO credentials for workspace pods to access object storage
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: workbench
+type: Opaque
+stringData:
+  minio-access-key: placeholder
+  minio-secret-key: placeholder
+
+---
+# minio-tenant-default/default-user
+# MinIO tenant user credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-user
+  namespace: minio-tenant-default
+type: Opaque
+stringData:
+  API_ACCESS_KEY: api-default-user
+  API_SECRET_KEY: placeholder
+  CONSOLE_ACCESS_KEY: placeholder
+  CONSOLE_SECRET_KEY: placeholder

--- a/docs/manual_helm_install/secrets/secrets-aiwb.yaml
+++ b/docs/manual_helm_install/secrets/secrets-aiwb.yaml
@@ -1,30 +1,15 @@
 # AIWB Standalone Secrets
-# This file contains only the secrets needed for AIWB standalone installation
-# All credentials use "placeholder" for development - replace with secure values for production
-
----
-# aiwb/aiwb-cnpg-superuser
-apiVersion: v1
-kind: Secret
-metadata:
-  name: aiwb-cnpg-superuser
-  namespace: aiwb
-type: Opaque
-stringData:
-  password: placeholder
-  username: placeholder
-
----
-# aiwb/aiwb-cnpg-user
-apiVersion: v1
-kind: Secret
-metadata:
-  name: aiwb-cnpg-user
-  namespace: aiwb
-type: Opaque
-stringData:
-  password: placeholder
-  username: aiwb_user
+# Application-level secrets needed for AIWB standalone installation that are
+# always required regardless of pluggable mode.
+#
+# CNPG-related secrets (aiwb-cnpg-*, keycloak-cnpg-*) live in
+# secrets-aiwb-cnpg.yaml — only applied when PLUGGABLE_DB=false.
+#
+# MinIO-related secrets (minio-credentials, default-user) live in
+# secrets-aiwb-minio.yaml — only applied when PLUGGABLE_S3=false.
+#
+# All credentials use "placeholder" for development — replace with secure
+# values for production.
 
 ---
 # aiwb/aiwb-nextauth-secret
@@ -63,20 +48,6 @@ stringData:
   value: placeholder
 
 ---
-# aiwb/minio-credentials
-# MinIO credentials for AIWB to access object storage
-# Must match the MinIO tenant root credentials
-apiVersion: v1
-kind: Secret
-metadata:
-  name: minio-credentials
-  namespace: aiwb
-type: Opaque
-stringData:
-  minio-access-key: placeholder
-  minio-secret-key: placeholder
-
----
 # keycloak/airm-realm-credentials
 # Initial credentials for airm realm setup
 apiVersion: v1
@@ -97,30 +68,6 @@ stringData:
   MINIO_CLIENT_SECRET: placeholder
 
 ---
-# keycloak/keycloak-cnpg-superuser
-apiVersion: v1
-kind: Secret
-metadata:
-  name: keycloak-cnpg-superuser
-  namespace: keycloak
-type: Opaque
-stringData:
-  password: placeholder
-  username: placeholder
-
----
-# keycloak/keycloak-cnpg-user
-apiVersion: v1
-kind: Secret
-metadata:
-  name: keycloak-cnpg-user
-  namespace: keycloak
-type: Opaque
-stringData:
-  password: placeholder
-  username: keycloak
-
----
 # keycloak/keycloak-credentials
 # Keycloak admin console credentials
 apiVersion: v1
@@ -131,31 +78,3 @@ metadata:
 type: Opaque
 stringData:
   KEYCLOAK_INITIAL_ADMIN_PASSWORD: placeholder
-
----
-# workbench/minio-credentials
-# MinIO credentials for workspace pods to access object storage
-apiVersion: v1
-kind: Secret
-metadata:
-  name: minio-credentials
-  namespace: workbench
-type: Opaque
-stringData:
-  minio-access-key: placeholder
-  minio-secret-key: placeholder
-
----
-# minio-tenant-default/default-user
-# MinIO tenant user credentials
-apiVersion: v1
-kind: Secret
-metadata:
-  name: default-user
-  namespace: minio-tenant-default
-type: Opaque
-stringData:
-  API_ACCESS_KEY: api-default-user
-  API_SECRET_KEY: placeholder
-  CONSOLE_ACCESS_KEY: placeholder
-  CONSOLE_SECRET_KEY: placeholder

--- a/docs/manual_helm_install/secrets/secrets.md
+++ b/docs/manual_helm_install/secrets/secrets.md
@@ -4,6 +4,8 @@
 
 - [Secret Sources](#secret-sources)
   - [secrets-aiwb.yaml](#secrets-aiwbyaml)
+  - [secrets-aiwb-cnpg.yaml](#secrets-aiwb-cnpgyaml)
+  - [secrets-aiwb-minio.yaml](#secrets-aiwb-minioyaml)
   - [secrets-override-hardcoded.yaml](#secrets-override-hardcodedyaml)
   - [secrets-aiwb-standalone.yaml](#secrets-aiwb-standaloneyaml)
 - [Complete Secret Reference](#complete-secret-reference)
@@ -21,7 +23,13 @@ Having an external secrets management system is a best practice, but for out-of-
 ## Secret Sources
 
 ### secrets-aiwb.yaml
-This manifest contains the base secrets for the AI Workbench deployment. It includes the necessary credentials and configurations required for the AI Workbench to function properly. All values use `placeholder` by default and should be replaced with secure credentials for production.
+This manifest contains the application-level secrets for the AI Workbench deployment that are always required regardless of pluggable mode. All values use `placeholder` by default and should be replaced with secure credentials for production.
+
+### secrets-aiwb-cnpg.yaml
+CNPG-specific Postgres credentials (superuser + application user) for the in-cluster CloudNativePG Clusters serving AIWB and Keycloak. `install_base.sh` only applies this file when `PLUGGABLE_DB=false`. In `PLUGGABLE_DB=true` mode the script instead creates env-based user secrets (`AIWB_DB_SECRET_NAME`, `KEYCLOAK_DB_SECRET_NAME`) populated from `AIWB_DB_USER` / `AIWB_DB_PASSWORD` and `KEYCLOAK_DB_USER` / `KEYCLOAK_DB_PASSWORD`.
+
+### secrets-aiwb-minio.yaml
+MinIO-related secrets: `minio-credentials` in the `aiwb` and `workbench` namespaces, plus `default-user` for the in-cluster MinIO Tenant. `install_base.sh` only applies this file when `PLUGGABLE_S3=false`. In `PLUGGABLE_S3=true` mode the script instead creates `minio-credentials` in `aiwb` and `workbench` from `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`, and `default-user` is not needed (no in-cluster Tenant is installed).
 
 ### secrets-override-hardcoded.yaml
 This manifest contains secrets with values that CANNOT be `placeholder` due to hardcoded expectations in Helm charts or other components. These override corresponding secrets from `secrets-aiwb.yaml`.
@@ -44,7 +52,7 @@ PostgreSQL superuser credentials for AIWB database cluster.
 - `username` — PostgreSQL admin username (default: `placeholder`)
 - `password` — PostgreSQL admin password (default: `placeholder`)
 
-**Source:** secrets-aiwb.yaml
+**Source:** secrets-aiwb-cnpg.yaml (applied only when `PLUGGABLE_DB=false`)
 
 ---
 
@@ -55,8 +63,8 @@ PostgreSQL application user credentials for AIWB database.
 - `username` — PostgreSQL username (**hardcoded:** `aiwb_user`)
 - `password` — PostgreSQL password (default: `placeholder`)
 
-**Source:** secrets-aiwb.yaml, secrets-override-hardcoded.yaml  
-**Note:** Username is hardcoded in AIWB Helm chart values.yaml
+**Source:** secrets-aiwb-cnpg.yaml, secrets-override-hardcoded.yaml (applied only when `PLUGGABLE_DB=false`)  
+**Note:** Username is hardcoded in AIWB Helm chart values.yaml. In `PLUGGABLE_DB=true` mode, replaced by env-based `${AIWB_DB_SECRET_NAME}` Secret.
 
 ---
 
@@ -100,8 +108,8 @@ S3/MinIO access credentials for AIWB application.
 - `minio-access-key` — S3 access key ID (default: `placeholder`)
 - `minio-secret-key` — S3 secret access key (default: `placeholder`)
 
-**Source:** secrets-aiwb.yaml  
-**Note:** Must match MinIO tenant root credentials or external S3 credentials
+**Source:** secrets-aiwb-minio.yaml (applied only when `PLUGGABLE_S3=false`)  
+**Note:** Must match MinIO tenant root credentials. In `PLUGGABLE_S3=true` mode, `install_base.sh` creates this Secret from `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` env vars instead.
 
 ---
 
@@ -114,7 +122,7 @@ PostgreSQL superuser credentials for Keycloak database cluster.
 - `username` — PostgreSQL admin username (default: `placeholder`)
 - `password` — PostgreSQL admin password (default: `placeholder`)
 
-**Source:** secrets-aiwb.yaml
+**Source:** secrets-aiwb-cnpg.yaml (applied only when `PLUGGABLE_DB=false`)
 
 ---
 
@@ -125,8 +133,8 @@ PostgreSQL application user credentials for Keycloak database.
 - `username` — PostgreSQL username (**hardcoded:** `keycloak`)
 - `password` — PostgreSQL password (default: `placeholder`)
 
-**Source:** secrets-aiwb.yaml, secrets-override-hardcoded.yaml  
-**Note:** Username is hardcoded in Keycloak Helm chart database configuration
+**Source:** secrets-aiwb-cnpg.yaml, secrets-override-hardcoded.yaml (applied only when `PLUGGABLE_DB=false`)  
+**Note:** Username is hardcoded in Keycloak Helm chart database configuration. In `PLUGGABLE_DB=true` mode, replaced by env-based `${KEYCLOAK_DB_SECRET_NAME}` Secret.
 
 ---
 
@@ -169,8 +177,8 @@ S3/MinIO access credentials for workspace pods.
 - `minio-access-key` — S3 access key ID (default: `placeholder`)
 - `minio-secret-key` — S3 secret access key (default: `placeholder`)
 
-**Source:** secrets-aiwb.yaml, secrets-aiwb-standalone.yaml  
-**Note:** Workspace pods use this to access object storage
+**Source:** secrets-aiwb-minio.yaml, secrets-aiwb-standalone.yaml (applied only when `PLUGGABLE_S3=false`)  
+**Note:** Workspace pods use this to access object storage. In `PLUGGABLE_S3=true` mode, `install_base.sh` creates this Secret from `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` env vars instead.
 
 ---
 
@@ -185,8 +193,8 @@ MinIO tenant user credentials.
 - `CONSOLE_ACCESS_KEY` — MinIO console access key (default: `placeholder`)
 - `CONSOLE_SECRET_KEY` — MinIO console secret key (default: `placeholder`)
 
-**Source:** secrets-aiwb.yaml, secrets-override-hardcoded.yaml  
-**Note:** API_ACCESS_KEY is hardcoded in OpenBao secret definitions
+**Source:** secrets-aiwb-minio.yaml, secrets-override-hardcoded.yaml (applied only when `PLUGGABLE_S3=false`)  
+**Note:** API_ACCESS_KEY is hardcoded in OpenBao secret definitions. Not needed in `PLUGGABLE_S3=true` mode (no in-cluster MinIO Tenant is installed).
 
 ---
 


### PR DESCRIPTION
EAI-6059

Goal: Prepare Cluster Forge side of Helm instructions to the point where next step is to create commits to other repositories than cluster-forge. 

## Summary

  Move the live parts of `scripts/s3.sh` into `install_base.sh`'s `PLUGGABLE_S3=true` branch so the install path is declarative end-to-end and `s3.sh` shrinks  to a non-destructive post-install verifier. Same shape applied to secret handling: CNPG and MinIO Secrets split out of `secrets-aiwb.yaml` so they can be applied conditionally per pluggable mode, with env-based replacements created in `install_base.sh` when in pluggable mode.

  Components touched:
  - **Secrets**: new `secrets-aiwb-cnpg.yaml` / `secrets-aiwb-minio.yaml`; `install_base.sh` applies each only when the corresponding in-cluster component is   being installed; in pluggable mode it creates env-based replacements (`AIWB_DB_SECRET_NAME`, `KEYCLOAK_DB_SECRET_NAME`, `minio-credentials` in `aiwb` and
  `workbench`).
  - **PLUGGABLE_S3 install_base.sh branch**: redirect Service `minio.minio-tenant-default.svc.cluster.local` → `${MINIO_HOST_IP}:${MINIO_PORT}` is now created   here (previously in `s3.sh`); idempotent `kubectl delete svc/endpoints` before apply so upgrades from `PLUGGABLE_S3=false` don't hit SSA conflicts.
  - **`scripts/s3.sh`**: reduced from ~320 → ~120 lines. Tenant deletion, Secret patches, namespace label fix, and `kubectl set env` / restart all removed.   Remaining script just prints AIWB's MinIO env, the `minio-credentials` access keys, the redirect Endpoints, and runs a curl pod against `/minio/health/live`.
  - **`scripts/pluggable.sh`**: `${PLUGGABLE_*:-false}` so pre-exported values pass through (previously unconditionally set to false).
  - **Docs**: `components/db.md` and `components/s3.md` rewritten for the `pluggable.sh`-based flow; `s3_minio_container.sh` instructions point at   `scripts/pluggable.sh` instead of the broken `pluggable/scripts/s3.sh` path.

The remaining redirect Service workaround exists because `silogen/aim-performance` workloads hardcode `BUCKET_STORAGE_HOST` to the in-cluster MinIO URL. Tracked separately as a Phase 3 follow-up across `silogen/core` and `silogen/aim-performance`; once those land, the redirect block and `s3.sh` can be removed.

  ## Test plan

  - [x] `PLUGGABLE_DB=false PLUGGABLE_S3=false ./scripts/install_base.sh <DOMAIN>` — in-cluster CNPG + MinIO path, all Secrets applied, no env-based block  triggers
  - [x] `PLUGGABLE_DB=true ./scripts/pluggable.sh <DOMAIN>` with `POSTGRES_HOST` etc. set — `secrets-aiwb-cnpg.yaml` skipped, `${AIWB_DB_SECRET_NAME}` /  `${KEYCLOAK_DB_SECRET_NAME}` created from env, AIWB and Keycloak come up against external Postgres
  - [x] `PLUGGABLE_S3=true ./scripts/pluggable.sh <DOMAIN>` with `MINIO_HOST` etc. set — `secrets-aiwb-minio.yaml` skipped, `minio-credentials` created from env   in `aiwb` and `workbench`, redirect Service points at `${MINIO_HOST_IP}:${MINIO_PORT}`, AIWB talks to external MinIO