### PR TITLE
EAI-6555: parametrize namespace in amd-gpu-operator-config chart

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -117,6 +117,8 @@ apps:
     namespace: kube-amd-gpu
     path: amd-gpu-operator-config
     syncWave: 0
+    valuesObject:
+      namespace: kube-amd-gpu
   appwrapper:
     namespace: appwrapper-system
     path: appwrapper/v1.1.2

--- a/sources/amd-gpu-operator-config/Chart.yaml
+++ b/sources/amd-gpu-operator-config/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: amd-gpu-operator-config
+description: A Helm chart with config for the AMD GPU Operator
+version: 0.1.0

--- a/sources/amd-gpu-operator-config/templates/configmap-gpu-config.yaml
+++ b/sources/amd-gpu-operator-config/templates/configmap-gpu-config.yaml
@@ -121,4 +121,4 @@ data:
 kind: ConfigMap
 metadata:
   name: gpu-config
-  namespace: kube-amd-gpu
+  namespace: {{ .Values.namespace }}

--- a/sources/amd-gpu-operator-config/templates/deviceconfig-example.yaml
+++ b/sources/amd-gpu-operator-config/templates/deviceconfig-example.yaml
@@ -4,7 +4,7 @@ metadata:
   # the names for the device plugin, metrics exporter and node labeler pods will be prefixed with this name
   name: gpu-operator
   # it is highly recommended to use the namespace where AMD GPU Operator is running
-  namespace: kube-amd-gpu
+  namespace: {{ .Values.namespace }}
 spec:
   driver:
     # set to ture for deploying out-of-tree driver with specified ROCm version 

--- a/sources/amd-gpu-operator-config/templates/manager-rolebinding-for-secrets.yaml
+++ b/sources/amd-gpu-operator-config/templates/manager-rolebinding-for-secrets.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: amd-gpu-operator-gpu-operator-charts-controller-manager
-  namespace: kube-amd-gpu
+  namespace: {{ .Values.namespace }}
  

--- a/sources/amd-gpu-operator-config/values.yaml
+++ b/sources/amd-gpu-operator-config/values.yaml
@@ -1,0 +1,1 @@
+namespace: kube-amd-gpu


### PR DESCRIPTION
## Motivation

AMD GPU Operator may be preinstalled (eg UQ OpenShift) in a different namespace than cluster-forge expects. As a result amd-gpu-operator-config's `DeviceConfig` needs to be in that namespace as well. 

The `kube-and-gpu` namespace is still the default and should maintain backwards compatibility with existing installations. But new installations can use a different namespace. 

## Summary
- Convert `sources/amd-gpu-operator-config/` from a plain manifest directory into a Helm chart (`Chart.yaml` + `values.yaml` + `templates/`).
- Replace hardcoded `namespace: kube-amd-gpu` in all three manifests (ConfigMap, ClusterRoleBinding, DeviceConfig) with `{{ .Values.namespace }}`.
- Pass the namespace from `root/values.yaml` via `valuesObject` so the ArgoCD destination namespace and the chart's resource namespaces stay in sync. Required for the ClusterRoleBinding's `subjects[].namespace`, which is part of resource content and cannot be overridden by ArgoCD's `destination.namespace`.

ArgoCD auto-detects the chart by the presence of `Chart.yaml`, so `root/templates/cluster-apps.yaml` needs no change.

## Test plan
- [x] `helm template test sources/amd-gpu-operator-config` → all three resources render with `namespace: kube-amd-gpu` (default).
- [x] `helm template test sources/amd-gpu-operator-config --set namespace=my-custom-ns` → all three render with the override.
- [x] ArgoCD sync of the `amd-gpu-operator-config` Application stays Synced/Healthy with the same three resources in `kube-amd-gpu`.