### PR TITLE
EAI-6555 Use Helm .Release.Namespace instead of extra valuesObject

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -120,8 +120,6 @@ apps:
     namespace: kube-amd-gpu
     path: amd-gpu-operator-config
     syncWave: 0
-    valuesObject:
-      namespace: kube-amd-gpu
   appwrapper:
     namespace: appwrapper-system
     path: appwrapper/v1.1.2

--- a/sources/amd-gpu-operator-config/templates/configmap-gpu-config.yaml
+++ b/sources/amd-gpu-operator-config/templates/configmap-gpu-config.yaml
@@ -121,4 +121,4 @@ data:
 kind: ConfigMap
 metadata:
   name: gpu-config
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/sources/amd-gpu-operator-config/templates/deviceconfig-example.yaml
+++ b/sources/amd-gpu-operator-config/templates/deviceconfig-example.yaml
@@ -4,7 +4,7 @@ metadata:
   # the names for the device plugin, metrics exporter and node labeler pods will be prefixed with this name
   name: gpu-operator
   # it is highly recommended to use the namespace where AMD GPU Operator is running
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   driver:
     # set to ture for deploying out-of-tree driver with specified ROCm version 

--- a/sources/amd-gpu-operator-config/templates/manager-rolebinding-for-secrets.yaml
+++ b/sources/amd-gpu-operator-config/templates/manager-rolebinding-for-secrets.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: amd-gpu-operator-gpu-operator-charts-controller-manager
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
  

--- a/sources/amd-gpu-operator-config/values.yaml
+++ b/sources/amd-gpu-operator-config/values.yaml
@@ -1,1 +1,0 @@
-namespace: kube-amd-gpu


### PR DESCRIPTION
Using Helm .Release.Namespace is consistent with amd-gpu-operator and other resources. 

## Summary
- Replace `.Values.namespace` with `.Release.Namespace` in the three `amd-gpu-operator-config` templates (ConfigMap, ClusterRoleBinding subject, DeviceConfig)
- Drop the now-unused `valuesObject.namespace` from `root/values.yaml` and the corresponding default from the chart's `values.yaml`
- ArgoCD already sets `.Release.Namespace` from the Application's `destination.namespace`, so the namespace stays a single source of truth and matches how `amd-gpu-operator` itself is parametrized

## Test plan
- [x] `helm template test sources/amd-gpu-operator-config --namespace kube-amd-gpu` renders all three resources in `kube-amd-gpu`
- [x] `helm template test sources/amd-gpu-operator-config --namespace doge` renders all three resources in `doge`
- [ ] ArgoCD sync of `amd-gpu-operator-config` Application succeeds on a dev cluster