### PR TITLE
EAI-5821: Add ext-proc metrics scraping and bump cluster-auth to rc4

### DIFF
--- a/sources/cluster-auth/0.5.9/values.yaml
+++ b/sources/cluster-auth/0.5.9/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/silogen/cluster-auth
   pullPolicy: Always
-  tag: "0.6.0-rc3"
+  tag: "0.6.0-rc4"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/sources/otel-lgtm-stack/v1.0.7/Chart.yaml
+++ b/sources/otel-lgtm-stack/v1.0.7/Chart.yaml
@@ -8,10 +8,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.7"
+appVersion: "1.0.8"

--- a/sources/otel-lgtm-stack/v1.0.7/templates/collectors-metrics-rest.yaml
+++ b/sources/otel-lgtm-stack/v1.0.7/templates/collectors-metrics-rest.yaml
@@ -121,6 +121,25 @@ spec:
               static_configs:
                 - targets:
                     - longhorn-backend.longhorn.svc.cluster.local:9500
+            - job_name: ai-gateway-extproc
+              scrape_interval: 30s
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names:
+                      - envoy-gateway-system
+              metrics_path: /metrics
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+                  regex: envoy
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_label_gateway_envoyproxy_io_owning_gateway_name]
+                  regex: https
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_ip]
+                  regex: (.+)
+                  replacement: $1:1064
+                  target_label: __address__
     service:
       pipelines:
         metrics:


### PR DESCRIPTION
## Summary

- Adds `ai-gateway-extproc` scrape job to the OTel rest collector — targets Envoy https proxy pods in `envoy-gateway-system` on port 1064 (the ext-proc sidecar admin port) using Kubernetes SD with label filters. No RBAC changes needed; the collector service account already has cluster-wide pod list/watch.
- Bumps `otel-lgtm-stack` v1.0.7 → v1.0.8 to carry the new scrape config
- Bumps `cluster-auth` image tag from 0.6.0-rc3 to 0.6.0-rc4, which adds `x-aim-service-id` header injection via SecurityPolicy contextExtensions

## Test plan

- [ ] OTel metrics-rest collector restarts cleanly with new config (no parse errors in logs)
- [ ] `gen_ai_client_token_usage` metrics appear in Grafana after a model request
- [ ] `x-aim-service-id` header is present on responses proxied through cluster-auth