### PR TITLE
Fix node-exporter port conflict by templatizing hardcoded port 9100

### DIFF
--- a/sources/otel-lgtm-stack/v1.0.7/templates/node-exporter.yaml
+++ b/sources/otel-lgtm-stack/v1.0.7/templates/node-exporter.yaml
@@ -95,7 +95,7 @@ spec:
             - --path.sysfs=/host/sys
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
-            - --web.listen-address=[$(HOST_IP)]:9100
+            - --web.listen-address=[$(HOST_IP)]:{{ .Values.services.nodeExporter.metrics }}
           securityContext:
             readOnlyRootFilesystem: true
           env:
@@ -103,14 +103,14 @@ spec:
               value: 0.0.0.0
           ports:
             - name: metrics
-              containerPort: 9100
+              containerPort: {{ .Values.services.nodeExporter.metrics }}
               protocol: TCP
           livenessProbe:
             failureThreshold: 3
             httpGet:
               httpHeaders:
               path: /
-              port: 9100
+              port: {{ .Values.services.nodeExporter.metrics }}
               scheme: HTTP
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -121,7 +121,7 @@ spec:
             httpGet:
               httpHeaders:
               path: /
-              port: 9100
+              port: {{ .Values.services.nodeExporter.metrics }}
               scheme: HTTP
             initialDelaySeconds: 0
             periodSeconds: 10


### PR DESCRIPTION
## Summary

- Replaces 4 hardcoded `9100` port references in the node-exporter DaemonSet template with `{{ .Values.services.nodeExporter.metrics }}`
- Default port remains `9100` (no change for clusters without conflicts)
- Clusters with a port conflict (e.g. AMD fleet-observability or systemd prometheus-node-exporter occupying 9100) can now override via `cluster-values`:

```yaml
apps:
  otel-lgtm-stack:
    helmParameters:
      - name: services.nodeExporter.metrics
        value: "9101"
```

## Background

On nodes where a host-level node_exporter already occupies port 9100 (AMD `fleet-observability` stack, Ubuntu `prometheus-node-exporter` systemd package), the cluster-forge DaemonSet pod enters CrashLoopBackOff immediately after bootstrap. The 4 hardcoded `9100` references prevented any per-cluster port override from working.


## Test plan

- [x] Deployed on ephemeral OCI test VM with bloom (`fix-node-exporter-port-template` branch)
- [x] Replicated port conflict using netcat to reserve port 9100 → confirmed CrashLoopBackOff
- [x] Applied `helmParameters` override in cluster-values → node-exporter came up Running on port 9101
- [x] Validated on workload-dev → both pods Running after DaemonSet delete + ArgoCD sync

Jira: EAI-6663

🤖 Generated with [Claude Code](https://claude.com/claude-code)