### PR TITLE
chore: replace bitnami image references with soldevelo equivalents

### DIFF
--- a/scripts/utils/envoy-gateway-migration.yaml
+++ b/scripts/utils/envoy-gateway-migration.yaml
@@ -179,7 +179,7 @@ spec:
       # Phase 2: Node Labeling (Main Container)
       containers:
       - name: node-labeling
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         command: ["/bin/bash"]
         args:
         - -c

--- a/scripts/utils/label-first-node-upgrade.yaml
+++ b/scripts/utils/label-first-node-upgrade.yaml
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: label-first-node-sa
       containers:
       - name: label-node-discoverer
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         command: ["/bin/bash"]
         args:
         - -c

--- a/sources/cluster-auth/0.5.0/templates/job-restart-envoygateway.yaml
+++ b/sources/cluster-auth/0.5.0/templates/job-restart-envoygateway.yaml
@@ -10,7 +10,7 @@ spec:
       serviceAccountName: {{ include "cluster-auth.fullname" . }}-restart-envoygateway-sa
       containers:
         - name: restart
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:latest
           command:
             - /bin/sh
             - -c

--- a/sources/cluster-auth/0.5.9/templates/job-restart-envoygateway.yaml
+++ b/sources/cluster-auth/0.5.9/templates/job-restart-envoygateway.yaml
@@ -10,7 +10,7 @@ spec:
       serviceAccountName: {{ include "cluster-auth.fullname" . }}-restart-envoygateway-sa
       containers:
         - name: restart
-          image: bitnami/kubectl:latest
+          image: soldevelo/kubectl:latest
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
## Why this change

Bitnami moved image updates behind a paywall on August 28 2025, and public images no longer receive ongoing updates.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements with active support.

## Image replacements

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)