### PR TITLE
EAI-5821: Bump cluster-auth from 0.6.0-rc5 to 0.6.0-rc6

### DIFF
--- a/sources/cluster-auth/0.5.9/values.yaml
+++ b/sources/cluster-auth/0.5.9/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/silogen/cluster-auth
   pullPolicy: Always
-  tag: "0.6.0-rc5"
+  tag: "0.6.0-rc6"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary

- Bumps cluster-auth image tag from `0.6.0-rc5` to `0.6.0-rc6` in `sources/cluster-auth/0.5.9/values.yaml`

## Test plan

- [ ] ArgoCD syncs and cluster-auth pod restarts on `0.6.0-rc6`
- [ ] Auth flow (API key → group check → allow/deny) works as expected after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)