### PR TITLE
fix(kyverno): set explicit replicas=1 for all controllers (EAI-6864)

### DIFF
--- a/sources/kyverno/3.5.1/values.yaml
+++ b/sources/kyverno/3.5.1/values.yaml
@@ -810,7 +810,7 @@ admissionController:
   createSelfSignedCert: false
 
   # -- (int) Desired number of pods
-  replicas: ~
+  replicas: 1
 
   # -- The number of revisions to keep
   revisionHistoryLimit: 10
@@ -1296,7 +1296,7 @@ backgroundController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas: ~
+  replicas: 1
 
   # -- The number of revisions to keep
   revisionHistoryLimit: 10
@@ -1581,7 +1581,7 @@ cleanupController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas: ~
+  replicas: 1
 
   # -- The number of revisions to keep
   revisionHistoryLimit: 10
@@ -1919,7 +1919,7 @@ reportsController:
     # - secretName
 
   # -- (int) Desired number of pods
-  replicas: ~
+  replicas: 1
 
   # -- The number of revisions to keep
   revisionHistoryLimit: 10


### PR DESCRIPTION
## Summary

- `sources/kyverno/3.5.1/values.yaml` had `replicas: ~` (YAML null) for all four Kyverno controllers
- The chart's null-replica guard in `_deployment.tpl` uses `kindIs "invalid"` which null passes — rendering empty string → Kubernetes coerces to 0 replicas
- This silently breaks the admission controller webhook on every fresh cluster-forge install, meaning generate policies (e.g. `dynamic-pvc-creation` for workspace PVCs) never fire
- Discovered when workspace pods were stuck in Pending on app-dev: `kyverno-admission-controller` had 0 desired replicas since cluster installation (2026-02-06)
- ArgoCD considered state `Synced` because live 0 replicas matched what the chart rendered — selfHeal never corrected it

**Fix:** Set `replicas: 1` explicitly for all four controllers (`admissionController`, `backgroundController`, `cleanupController`, `reportsController`). Clusters needing HA can override via their `cluster-values`.

**Upstream bug:** kyverno/kyverno#8941, #6182

**Jira:** [EAI-6864](https://amd.atlassian.net/browse/EAI-6864)

**Immediate workaround already applied:** cluster-values override on app-dev sets `admissionController.replicas: 1` — that override can be removed once this PR is deployed to app-dev.

## Test plan

- [x] Verify `kyverno-admission-controller` deploys with 1 replica on a fresh cluster install
- [x] Verify `dynamic-pvc-creation` ClusterPolicy fires on workspace deployment (PVC created, pod reaches Running)
- [x] Verify existing clusters with cluster-values override continue to work after this fix is synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EAI-6864]: https://amd.atlassian.net/browse/EAI-6864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ