### PR TITLE
EAI Suite -> EAI reference stack

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,11 +1,11 @@
 # Cluster-Forge Product Requirements Document (PRD)
 
-## Note for Users who wish to install the full AMD Enterprise AI Suite
-A note has been placed at the top of the README.md file in this repository to clarify most users may be looking to install the full AMD Enterprise Suite, not just using this repo. Specifically a link is provided to the official Enterprise on-premise installation [here](https://enterprise-ai.docs.amd.com/en/latest/platform-infrastructure/on-premises-installation.html)
+## Note for Users who wish to install the full AMD Enterprise AI reference Stack
+A note has been placed at the top of the README.md file in this repository to clarify most users may be looking to install the full AMD Enterprise reference stack, not just using this repo. Specifically a link is provided to the official Enterprise on-premise installation [here](https://enterprise-ai.docs.amd.com/en/latest/platform-infrastructure/on-premises-installation.html)
 
 ## Executive Summary
 
-**Cluster-Forge** is a Kubernetes platform automation tool that bundles third-party, community, and in-house components into a single, GitOps-managed stack deployable in Kubernetes clusters. It automates the deployment of a complete AI/ML compute platform built on AMD Enterprise AI Suite components, delivering consistent, production-ready clusters with all essential services pre-configured and integrated.
+**Cluster-Forge** is a Kubernetes platform automation tool that bundles third-party, community, and in-house components into a single, GitOps-managed stack deployable in Kubernetes clusters. It automates the deployment of a complete AI/ML compute platform built on AMD Enterprise AI reference stack components, delivering consistent, production-ready clusters with all essential services pre-configured and integrated.
 
 The platform uses ArgoCD's app-of-apps pattern with a sophisticated bootstrap process that establishes GitOps infrastructure (ArgoCD, Gitea, OpenBao) before deploying the complete application stack.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Cluster-Forge
 > [!IMPORTANT]
-> #### *Instructions for installing the AMD Enterprise AI Suite (for most users) are [here](https://enterprise-ai.docs.amd.com/en/latest/platform-infrastructure/on-premises-installation.html)*
+> #### *Instructions for installing the AMD Enterprise AI reference stack (for most users) are [here](https://enterprise-ai.docs.amd.com/en/latest/platform-infrastructure/on-premises-installation.html)*
 
-### A Kubernetes platform automation tool that deploys [AMD Enterprise AI Suite](https://enterprise-ai.docs.amd.com/en/latest/) with complete GitOps infrastructure.
+### A Kubernetes platform automation tool that deploys [AMD Enterprise AI reference stack](https://enterprise-ai.docs.amd.com/en/latest/) with complete GitOps infrastructure.
 
 
 

--- a/docs/backup_and_restore.md
+++ b/docs/backup_and_restore.md
@@ -1,4 +1,4 @@
-# AMD Enterprise AI Suite - Backup and Restore Procedures
+# AMD Enterprise AI reference stack - Backup and Restore Procedures
 
 ⚠️ Important Notes & Disclaimers
   - The AMD Resouce Manager is internally referenced as `airm`, hence the namespace and resource prefixes (understand that they are the same). 

--- a/docs/manual_helm_install/README.md
+++ b/docs/manual_helm_install/README.md
@@ -3,7 +3,7 @@
 This guide explains how to deploy AI Workbench on a Kubernetes cluster, including the base required components and optional pluggable components that can be substituted with your own implementations.
 
 > **Full platform (AIRM + AIWB)**: This guide covers **standalone AIWB** deployments.
-> For the full AMD Enterprise AI Suite — including AI Resource Manager (AIRM) for
+> For the full AMD Enterprise AI reference steack — including AI Resource Manager (AIRM) for
 > multi-tenant resource management, cluster coordination, and GPU resource allocation —
 > see the [Helm Installation Guide](https://github.com/amd-enterprise-ai/amd-eai-suite/blob/main/helm/INSTALL.md)
 > in the core repository.
@@ -373,7 +373,7 @@ Complete list of components and their versions:
 ### Full Platform (AIRM + AIWB)
 
 These components are **not required** for standalone AIWB but are needed if you
-want the full AMD Enterprise AI Suite with multi-tenant resource management.
+want the full AMD Enterprise AI reference stack with multi-tenant resource management.
 See the [core repo Helm Installation Guide](https://github.com/amd-enterprise-ai/amd-eai-suite/blob/main/helm/INSTALL.md)
 for complete instructions.
 


### PR DESCRIPTION
What was used to be called the AMD Enterprise AI Suite is now called the AMD Enterprise AI reference stack. This PR updates the ClusterForge documentation to reflect this.