### PR TITLE
fix: scrape ai-gateway-extproc on all gateway pods

### DIFF
--- a/sources/otel-lgtm-stack/v1.0.7/templates/collectors-metrics-rest.yaml
+++ b/sources/otel-lgtm-stack/v1.0.7/templates/collectors-metrics-rest.yaml
@@ -133,9 +133,6 @@ spec:
                 - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
                   regex: envoy
                   action: keep
-                - source_labels: [__meta_kubernetes_pod_label_gateway_envoyproxy_io_owning_gateway_name]
-                  regex: https
-                  action: keep
                 - source_labels: [__meta_kubernetes_pod_ip]
                   regex: (.+)
                   replacement: $1:1064


### PR DESCRIPTION
## Summary

- The `ai-gateway-extproc` OTel scrape job was filtering on `gateway.envoyproxy.io/owning-gateway-name == https`, so only the `https` gateway pod's extproc sidecar was scraped
- After splitting inference traffic to the separate `ai-gateway`, the extproc sidecar on that pod was never scraped — causing **zero metrics** for all workbench model deployments
- Fix: remove the gateway name filter; namespace (`envoy-gateway-system`) + app name (`envoy`) is sufficient to select all Envoy proxy pods with the extproc sidecar

## Context

This was discovered during testing of the new `ai-gateway` setup. API key auth works fine (403 on bad tokens, 200 on valid), requests land on vLLM correctly, but the AIWB API metrics endpoint returns all zeros because `gen_ai_client_token_usage_sum` and `gen_ai_server_request_duration_seconds_count` are never scraped from the `ai-gateway` pod.

## Test plan

- [ ] After deploying, confirm `gen_ai_client_token_usage_sum` metrics appear with `owning_gateway_name=ai-gateway` pod labels in Prometheus
- [ ] Confirm API key metrics dashboard shows request/token counts for workbench deployments