### PR TITLE
EAI-5821: fix ai-gateway-extproc scrape to populate pod label and cover both gateways

### DIFF
--- a/sources/otel-lgtm-stack/v1.0.7/templates/collectors-metrics-rest.yaml
+++ b/sources/otel-lgtm-stack/v1.0.7/templates/collectors-metrics-rest.yaml
@@ -137,6 +137,8 @@ spec:
                   regex: (.+)
                   replacement: $1:1064
                   target_label: __address__
+                - source_labels: [__meta_kubernetes_pod_name]
+                  target_label: pod
     service:
       pipelines:
         metrics:


### PR DESCRIPTION
## Summary

- Remove `regex: https` keep filter from `ai-gateway-extproc` scrape job so both the `https` and `ai-gateway` Envoy pods are scraped (previously only the `https` gateway was being scraped, causing zero metrics for all workbench AI deployments)
- Add `pod` relabel rule from `__meta_kubernetes_pod_name` so the `pod` label is populated — the AIWB API metrics queries filter on `pod!=""` for deduplication, and without this label all data was silently excluded

## Test plan

- [ ] After ArgoCD syncs, verify OTel collector scrapes both Envoy pods (`ai-gateway` + `https`)
- [ ] Send requests with an API key and confirm metrics appear in the AIWB UI dashboard (API key metrics endpoint)
- [ ] Verify `gen_ai_client_token_usage_sum{pod!=""}` returns data in Prometheus