### PR TITLE
EAI-5821: fix ai-gateway-extproc scrape to cover all gateway pods

### DIFF
--- a/sources/otel-lgtm-stack/v1.0.7/templates/collectors-logs-metrics-k8s.yaml
+++ b/sources/otel-lgtm-stack/v1.0.7/templates/collectors-logs-metrics-k8s.yaml
@@ -673,9 +673,9 @@ spec:
                   - envoy-gateway-system
               relabel_configs:
               - action: keep
-                regex: https
+                regex: envoy
                 source_labels:
-                - __meta_kubernetes_pod_label_gateway_envoyproxy_io_owning_gateway_name
+                - __meta_kubernetes_pod_label_app_kubernetes_io_name
               - action: replace
                 regex: (.+)
                 replacement: $1:1064

--- a/sources/otel-lgtm-stack/v1.0.7/templates/collectors-metrics-rest.yaml
+++ b/sources/otel-lgtm-stack/v1.0.7/templates/collectors-metrics-rest.yaml
@@ -121,24 +121,6 @@ spec:
               static_configs:
                 - targets:
                     - longhorn-backend.longhorn.svc.cluster.local:9500
-            - job_name: ai-gateway-extproc
-              scrape_interval: 30s
-              kubernetes_sd_configs:
-                - role: pod
-                  namespaces:
-                    names:
-                      - envoy-gateway-system
-              metrics_path: /metrics
-              relabel_configs:
-                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
-                  regex: envoy
-                  action: keep
-                - source_labels: [__meta_kubernetes_pod_ip]
-                  regex: (.+)
-                  replacement: $1:1064
-                  target_label: __address__
-                - source_labels: [__meta_kubernetes_pod_name]
-                  target_label: pod
     service:
       pipelines:
         metrics:


### PR DESCRIPTION
## Summary

The `ai-gateway-extproc` scrape was split across two OTel collectors (`metrics-k8s` and `metrics-rest`) and both had a `regex: https` filter that targeted only the `https` gateway pod. When EAI-5821 split AI traffic to a dedicated `ai-gateway` pod, the extproc metrics stopped being collected for that pod.

Root cause: `otel-collector-metrics-k8s` was the canonical scraper (it set the `pod` label that the AIWB API queries require). It had `regex: https` locking it to the old gateway. `metrics-rest` had a duplicate job without the `pod` label.

Changes:
- **`collectors-logs-metrics-k8s.yaml`**: Replace `gateway_envoyproxy_io_owning_gateway_name=https` filter with `app_kubernetes_io_name=envoy` so all Envoy gateway pods are scraped (both `https` and `ai-gateway`). Keep existing `pod`/`namespace` relabeling.
- **`collectors-metrics-rest.yaml`**: Remove the duplicate `ai-gateway-extproc` job — `metrics-k8s` is the canonical home; having both scrape the same endpoints would double-count tokens in the AIWB metrics dashboard.

## Test plan

- [ ] After ArgoCD syncs, confirm `gen_ai_client_token_usage_sum{pod!=""}` returns data for both `https` and `ai-gateway` pods in Prometheus
- [ ] Send requests and verify AIWB API key metrics dashboard shows non-zero token counts