### PR TITLE
EAI-7043: fix UUID-based AIM routing via Lua filter

### DIFF
--- a/sources/cluster-auth/0.5.9/values.yaml
+++ b/sources/cluster-auth/0.5.9/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/silogen/cluster-auth
   pullPolicy: Always
-  tag: "0.6.0-rc8"
+  tag: "0.6.0-rc9"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/sources/cluster-auth/0.5.9/values.yaml
+++ b/sources/cluster-auth/0.5.9/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/silogen/cluster-auth
   pullPolicy: Always
-  tag: "0.6.0-rc9"
+  tag: "0.6.0-rc10"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
+++ b/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
@@ -44,7 +44,7 @@ spec:
               authority: "%REQ(:AUTHORITY)%"
               backendHost: "%UPSTREAM_HOST%"
               backendCluster: "%UPSTREAM_CLUSTER%"
-              model: "%REQ(x-ai-eg-model-log)%"
+              model: "%REQ(x-ai-eg-model)%"
               llm_input_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               llm_output_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
               llm_total_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"

--- a/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
+++ b/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
@@ -44,7 +44,7 @@ spec:
               authority: "%REQ(:AUTHORITY)%"
               backendHost: "%UPSTREAM_HOST%"
               backendCluster: "%UPSTREAM_CLUSTER%"
-              model: "%REQ(x-ai-eg-model)%"
+              model: "%REQ(x-ai-eg-model-log)%"
               llm_input_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_input_token)%"
               llm_output_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
               llm_total_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"

--- a/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
@@ -1,14 +1,17 @@
 {{- if .Values.aiGateway.enabled }}
-# Lua filter that extracts routing headers from the request body before ext_authz runs,
-# on the ai-gateway (where all AI traffic terminates and is authorized).
+# Lua filter that extracts routing and logging headers from the request body before
+# ext_authz runs, on the ai-gateway (where all AI traffic terminates and is authorized).
+#
+# x-ai-eg-model-log is always set from the body's "model" field (when present) so the
+# access log can attribute requests to a model regardless of routing path.
 #
 # When "backend" (AIM UUID) is present in the body or already set as a request header,
-# only x-ai-eg-backend is set and the filter returns early. x-ai-eg-model is intentionally
-# NOT set in this case so that model-name fallback rules in other HTTPRoutes cannot match —
-# the UUID rule wins by specificity over catch-all rules without any cross-route ordering
-# dependency (EAI-7043).
+# only x-ai-eg-backend is set for routing and the filter returns early. x-ai-eg-model is
+# intentionally NOT set in this case so that model-name fallback rules in other HTTPRoutes
+# cannot match — the UUID rule wins by specificity over catch-all rules without any
+# cross-route ordering dependency (EAI-7043).
 #
-# When "backend" is absent, x-ai-eg-model is set from the body for standard
+# When "backend" is absent, x-ai-eg-model is also set from the body for standard
 # OpenAI-compatible clients so cluster-auth can match the correct per-model route and
 # enforce cluster-auth/allowed-group (EAI-6805).
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -31,17 +34,21 @@ spec:
           end
           local body_str = tostring(body)
           local backend = body_str:match('"backend"%s*:%s*"([^"]+)"')
+          local model = body_str:match('"model"%s*:%s*"([^"]+)"')
           if backend ~= nil then
             request_handle:headers():replace("x-ai-eg-backend", backend)
+            if model ~= nil then
+              request_handle:headers():replace("x-ai-eg-model-log", model)
+            end
             return
           end
           local existing_backend = request_handle:headers():get("x-ai-eg-backend")
           if existing_backend ~= nil and existing_backend ~= "" then
             return
           end
-          local model = body_str:match('"model"%s*:%s*"([^"]+)"')
           if model ~= nil then
             request_handle:headers():replace("x-ai-eg-model", model)
+            request_handle:headers():replace("x-ai-eg-model-log", model)
           end
         end
 {{- end }}

--- a/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
@@ -1,15 +1,16 @@
 {{- if .Values.aiGateway.enabled }}
-# Lua filter that sets x-ai-eg-model from the request body before ext_authz runs, on the
-# ai-gateway (where all AI traffic terminates and is authorized).
+# Lua filter that extracts routing headers from the request body before ext_authz runs,
+# on the ai-gateway (where all AI traffic terminates and is authorized).
 #
-# The AI Gateway's ext_proc reads the body and sets x-ai-eg-model, but it is inserted via
-# xdsTranslator post-hooks which run after filterOrder is applied. So ext_authz (cluster-auth)
-# would run without x-ai-eg-model and fall through to a catch-all route with no auth
-# annotations, allowing the request regardless of which model is targeted (EAI-6805).
+# When "backend" (AIM UUID) is present in the body or already set as a request header,
+# only x-ai-eg-backend is set and the filter returns early. x-ai-eg-model is intentionally
+# NOT set in this case so that model-name fallback rules in other HTTPRoutes cannot match —
+# the UUID rule wins by specificity over catch-all rules without any cross-route ordering
+# dependency (EAI-7043).
 #
-# This Lua filter runs early (ordered before ext_authz via the ai-gateway EnvoyProxy
-# filterOrder), reads the model field from the JSON body, and sets x-ai-eg-model so
-# cluster-auth can match the correct per-model route and enforce cluster-auth/allowed-group.
+# When "backend" is absent, x-ai-eg-model is set from the body for standard
+# OpenAI-compatible clients so cluster-auth can match the correct per-model route and
+# enforce cluster-auth/allowed-group (EAI-6805).
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyExtensionPolicy
 metadata:
@@ -28,7 +29,17 @@ spec:
           if body == nil then
             return
           end
-          local model = tostring(body):match('"model"%s*:%s*"([^"]+)"')
+          local body_str = tostring(body)
+          local backend = body_str:match('"backend"%s*:%s*"([^"]+)"')
+          if backend ~= nil then
+            request_handle:headers():replace("x-ai-eg-backend", backend)
+            return
+          end
+          local existing_backend = request_handle:headers():get("x-ai-eg-backend")
+          if existing_backend ~= nil and existing_backend ~= "" then
+            return
+          end
+          local model = body_str:match('"model"%s*:%s*"([^"]+)"')
           if model ~= nil then
             request_handle:headers():replace("x-ai-eg-model", model)
           end

--- a/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
@@ -1,19 +1,11 @@
 {{- if .Values.aiGateway.enabled }}
-# Lua filter that extracts routing and logging headers from the request body before
-# ext_authz runs, on the ai-gateway (where all AI traffic terminates and is authorized).
+# Lua filter that extracts routing headers from the request body before ext_authz runs,
+# on the ai-gateway (where all AI traffic terminates and is authorized).
 #
-# x-ai-eg-model-log is always set from the body's "model" field (when present) so the
-# access log can attribute requests to a model regardless of routing path.
-#
-# When "backend" (AIM UUID) is present in the body or already set as a request header,
-# only x-ai-eg-backend is set for routing and the filter returns early. x-ai-eg-model is
-# intentionally NOT set in this case so that model-name fallback rules in other HTTPRoutes
-# cannot match — the UUID rule wins by specificity over catch-all rules without any
-# cross-route ordering dependency (EAI-7043).
-#
-# When "backend" is absent, x-ai-eg-model is also set from the body for standard
-# OpenAI-compatible clients so cluster-auth can match the correct per-model route and
-# enforce cluster-auth/allowed-group (EAI-6805).
+# Both x-ai-eg-backend and x-ai-eg-model are set from the request body so that the
+# 3-condition UUID rule (Host + x-ai-eg-backend + x-ai-eg-model) wins by specificity
+# over any catch-all rules in other HTTPRoutes, regardless of HTTPRoute creation order.
+# The model-name fallback rule has been removed — clients must supply a backend UUID.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyExtensionPolicy
 metadata:
@@ -37,18 +29,9 @@ spec:
           local model = body_str:match('"model"%s*:%s*"([^"]+)"')
           if backend ~= nil then
             request_handle:headers():replace("x-ai-eg-backend", backend)
-            if model ~= nil then
-              request_handle:headers():replace("x-ai-eg-model-log", model)
-            end
-            return
-          end
-          local existing_backend = request_handle:headers():get("x-ai-eg-backend")
-          if existing_backend ~= nil and existing_backend ~= "" then
-            return
           end
           if model ~= nil then
             request_handle:headers():replace("x-ai-eg-model", model)
-            request_handle:headers():replace("x-ai-eg-model-log", model)
           end
         end
 {{- end }}


### PR DESCRIPTION
## Summary

- Lua filter (`set-model-header-from-body`) now skips setting `x-ai-eg-model` when a `backend` UUID is present in the request body or headers, so model-name fallback rules in other HTTPRoutes cannot match. The UUID rule (Host + `x-ai-eg-backend`) wins by specificity over catch-all rules regardless of HTTPRoute creation order.
- Introduces `x-ai-eg-model-log` header, always set from the body's `model` field, so the access log retains model attribution for both UUID-routed and model-name-routed requests.
- Access log format updated to read `x-ai-eg-model-log` instead of `x-ai-eg-model`.

## Root cause

Envoy Gateway merges HTTPRoute rules maintaining per-route creation-timestamp ordering, not global specificity. Two rules with equal header-match counts from different HTTPRoutes — the older route always wins. When two AIMs serve the same model, the first-created route's model-name rule would always win, routing to the wrong AIM regardless of the `x-ai-eg-backend` header.

## Test plan

- [ ] Deploy to app-dev and send a request with `"backend": "<uuid>"` in the body; verify `backendCluster` in access log shows the correct AIM's HTTPRoute rule
- [ ] Verify `model` field in access log is still populated for UUID requests
- [ ] Verify model-name routing (no `backend` field) still works for standard OpenAI clients