### PR TITLE
EAI-7230: Rate-limiting PoC (RL-1) — per-key request + token enforcement

### DIFF
--- a/docs/rate-limit-spike.md
+++ b/docs/rate-limit-spike.md
@@ -3,6 +3,47 @@
 Proves native, per-API-key request + generation-token enforcement on the AI gateway using
 Envoy Gateway global/cost-based rate limiting backed by Redis. No proxy or upstream code.
 
+## Results — GO (executed 2026-06-30 on app-dev, EG v1.7.1)
+
+Per-API-key request **and** generation-token enforcement work end-to-end with zero code in
+the auth/proxy path. The engine is essentially turnkey; what's left is the product layer.
+
+**Evidence.** With a 5 req/min + 100 output-token/min policy keyed on a real key's
+`x-api-key-id`, six back-to-back `Hello` calls produced:
+
+```
+200(55 tok) → 200(49 tok) → 429 → 429 → 429 → 200
+```
+
+- 55+49 = 104 output tokens spent the 100-token budget → requests 3–5 got **429**.
+- Access log on `ai-gateway` showed `response_code=429, response_flags=RL` (Envoy rate-limited).
+- Redis held two fixed-window buckets keyed per rule: request-count `=5`, token-count `=104`
+  for the burst minute; a fresh bucket for the next minute (which let request 6 through).
+- A 429 firing at all **confirms ext_authz runs before the rate-limit filter** — `x-api-key-id`
+  was present at limiting time, so the documented ordering risk is a non-issue.
+
+**Identifier — per-API-key works out of the box.** `x-api-key-id` is the OpenBao token
+DisplayName, which AIWB mints as `token-<namespace>-<apikeyname>` (unique constraint on
+`(display_name, namespace)`; namespaces globally unique). So the value is **globally unique
+per API key** — the policy selector gives true per-key granularity with no cluster-auth change
+and without keying on anything sensitive (the bearer token never touches the limit key).
+
+**Deploy safety (observed).** Deploying the branch was inert: no policy renders by default,
+and EG **auto-activated the rate-limit backend on the ConfigMap change without a controller
+restart** (controller pod untouched). Inference stayed 200 throughout. Removing the test BTP
+(applied via `kubectl`, not git) returned instantly to normal.
+
+**Carry-forward findings (for RL-2…RL-7):**
+1. **Fixed windows, not sliding** — counters reset on wall-clock boundaries; bursty at edges.
+   Informs which windows RL-3 offers.
+2. **Token overshoot-by-one** — the budget is charged *after* the response, so the request that
+   crosses the line completes and the *next* one is blocked.
+3. **Bare 429** — no informative body/headers today (`response_flags=RL` only) → RL-6 shaping.
+4. **Fail-open only** — v1.7.1's `BackendTrafficPolicy` has no `failClosed` field, so a
+   Redis/ratelimit outage cannot block model traffic. Accept, or revisit if a hard cap is needed.
+
+The steps below are the original runbook, kept for reproducibility.
+
 ## What this branch changes
 
 | Change | File |
@@ -44,7 +85,9 @@ $K get envoyproxy ai-gateway-proxy-config -o yaml | grep -A6 filterOrder
 ## Step 3 — plug in a real key and enforce
 
 Once we have a real API key on app-dev and the model it can reach, set its `x-api-key-id`
-(= the key's username) and flip the policy on. Two options:
+(the OpenBao DisplayName AIWB mints as `token-<namespace>-<apikeyname>` — globally unique per
+key; harvest the exact value from the `ai-gateway` access log field `api_key_id`) and flip the
+policy on. Two options:
 
 **A. Via GitOps (clean):** set in `cluster-values` and redeploy —
 `rateLimit.policy.enabled=true`, `rateLimit.policy.apiKeyId=<id>`, optionally tune

--- a/docs/rate-limit-spike.md
+++ b/docs/rate-limit-spike.md
@@ -1,0 +1,88 @@
+# Rate-limiting spike (RL-1) — runbook
+
+Proves native, per-API-key request + generation-token enforcement on the AI gateway using
+Envoy Gateway global/cost-based rate limiting backed by Redis. No proxy or upstream code.
+
+## What this branch changes
+
+| Change | File |
+| --- | --- |
+| Enable EG global rate-limit service, point it at in-cluster Redis | `root/values.yaml` → `config.envoyGateway.rateLimit.backend` |
+| Ephemeral Redis (Deployment + Service, no persistence/HA) | `sources/envoy-gateway-config/templates/ratelimit-redis.yaml` |
+| Per-key `BackendTrafficPolicy` (request + token-budget rules) | `sources/envoy-gateway-config/templates/backend-traffic-policy-ratelimit.yaml` |
+| Toggles + policy params | `sources/envoy-gateway-config/values.yaml` → `rateLimit.*` |
+
+Defaults: `rateLimit.enabled: true` (Redis + backend), `rateLimit.policy.enabled: false`
+(no policy renders until we supply a real key). So deploying the branch readies the infra
+and enforces nothing.
+
+## Step 1 — deploy the branch
+
+Deploy `spike/rate-limiting-poc` to app-dev. Then confirm the infra came up:
+
+```bash
+K="./kubectl --context app-dev-1 -n envoy-gateway-system"
+$K get deploy ratelimit-redis                 # Redis up
+$K get pods -l app.kubernetes.io/name=envoy-ratelimit -A   # EG ratelimit service up
+$K logs deploy/envoy-gateway | grep -i ratelimit | tail    # connected to Redis, no errors
+```
+
+Expected: `ratelimit-redis` Ready 1/1, an `envoy-ratelimit` pod Running, EG logs show the
+rate-limit backend healthy. **Inference traffic must be unaffected at this point** (no policy yet).
+
+## Step 2 — verify filter ordering (the one real risk)
+
+The rate-limit filter must run **after** ext_authz, or `x-api-key-id` is absent when limiting
+runs. The ai-gateway EnvoyProxy already sets `lua before ext_authz`; confirm ext_authz precedes
+ratelimit in the live config:
+
+```bash
+$K get envoyproxy ai-gateway-proxy-config -o yaml | grep -A6 filterOrder
+# if needed, dump the proxy's HTTP filter chain to confirm ext_authz -> ratelimit order
+```
+
+## Step 3 — plug in a real key and enforce
+
+Once we have a real API key on app-dev and the model it can reach, set its `x-api-key-id`
+(= the key's username) and flip the policy on. Two options:
+
+**A. Via GitOps (clean):** set in `cluster-values` and redeploy —
+`rateLimit.policy.enabled=true`, `rateLimit.policy.apiKeyId=<id>`, optionally tune
+`requests`/`tokens` and `targetRef`.
+
+**B. Via kubectl (fast spike iteration):** render and apply directly —
+```bash
+helm template t sources/envoy-gateway-config --set domain=<domain> --set aiGateway.enabled=true \
+  --set rateLimit.policy.enabled=true --set rateLimit.policy.apiKeyId=<id> \
+  --show-only templates/backend-traffic-policy-ratelimit.yaml | $K apply -f -
+```
+(Default policy: 5 requests/min and 1000 output-tokens/min for that key, attached to the
+`ai-gateway` Gateway.)
+
+## Step 4 — prove enforcement
+
+With a known-good `curl` against the model using that key:
+
+1. **Request limit:** fire >5 calls in a minute → expect HTTP **429** after the 5th.
+2. **Token budget:** make calls that generate >1000 output tokens in a window → subsequent
+   calls **429** once the budget is spent. Note the timing caveat: the budget is charged from
+   the *previous* response's `llm_output_token`, so the request that crosses the line still
+   succeeds (slight overshoot) and the next one is blocked.
+3. **Isolation:** a *different* key keeps working while the limited key is throttled.
+4. **Shared across replicas:** counts hold even when requests land on different Envoy pods
+   (Redis is the shared store).
+
+## Decisions to capture for RL-2 / RL-3
+
+- Redis HA + persistence posture (this spike is ephemeral, in-memory).
+- Windows to offer (min/hour/day).
+- Confirm "generation tokens" = `llm_output_token` (vs total).
+- Per-service limits → narrow `targetRef` from the Gateway to the per-service HTTPRoute, or
+  add an `x-aim-service-id` clientSelector (header already present).
+- Overshoot-by-one acceptable as the token-accounting model?
+
+## Teardown
+
+Set `rateLimit.enabled=false` (removes Redis + policy) and redeploy, or
+`kubectl delete backendtrafficpolicy ratelimit-spike deploy/ratelimit-redis svc/ratelimit-redis`
+plus revert the `root/values.yaml` backend block.

--- a/root/values.yaml
+++ b/root/values.yaml
@@ -607,6 +607,16 @@ apps:
         envoyGateway:
           extensionApis:
             enableBackend: true
+          # SPIKE (rate-limiting PoC): enable the global rate-limit service and point it at
+          # the in-cluster Redis deployed by the envoy-gateway-config chart (rateLimit.enabled).
+          # This is what makes BackendTrafficPolicy global/cost-based rules (per-key request +
+          # token-budget limits) actually enforce. Graduate to RL-2 (HA/persistence decision)
+          # before this leaves spike status.
+          rateLimit:
+            backend:
+              type: Redis
+              redis:
+                url: ratelimit-redis.envoy-gateway-system.svc.cluster.local:6379
           extensionManager:
             # Tolerate the AI extension erroring on the tls-passthrough gateway's L4
             # listener (it tries to splice an HTTP filter into a TCP chain with no

--- a/sources/envoy-gateway-config/templates/backend-traffic-policy-ratelimit.yaml
+++ b/sources/envoy-gateway-config/templates/backend-traffic-policy-ratelimit.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.rateLimit.enabled .Values.rateLimit.policy.enabled .Values.rateLimit.policy.apiKeyId }}
+# SPIKE (rate-limiting PoC): per-API-key global rate limit proving native enforcement.
+# Two rules, both scoped to a single key via the x-api-key-id header (injected by
+# cluster-auth ext_authz):
+#   1. request-count    — N requests per window
+#   2. token-budget      — M generation (output) tokens per window, charged from the
+#                          AI gateway's dynamic metadata io.envoy.ai_gateway:llm_output_token
+#                          (emitted by AIGatewayRoute.spec.llmRequestCosts in ai-gateway-discovery).
+#
+# Renders only when rateLimit.policy.apiKeyId is set, so deploying the branch with defaults
+# enforces nothing. Targets the ai-gateway Gateway by default; ext_authz must run before the
+# rate-limit filter or x-api-key-id is absent at limiting time — verify before relying on it.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: ratelimit-spike
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: {{ .Values.rateLimit.policy.targetRef.group | quote }}
+      kind: {{ .Values.rateLimit.policy.targetRef.kind | quote }}
+      name: {{ .Values.rateLimit.policy.targetRef.name | quote }}
+  rateLimit:
+    type: Global
+    global:
+      rules:
+        # Rule 1 — request count per key
+        - clientSelectors:
+            - headers:
+                - name: x-api-key-id
+                  value: {{ .Values.rateLimit.policy.apiKeyId | quote }}
+          limit:
+            requests: {{ .Values.rateLimit.policy.requests.limit }}
+            unit: {{ .Values.rateLimit.policy.requests.unit }}
+        # Rule 2 — generation-token budget per key (cost charged from response metadata)
+        - clientSelectors:
+            - headers:
+                - name: x-api-key-id
+                  value: {{ .Values.rateLimit.policy.apiKeyId | quote }}
+          limit:
+            requests: {{ .Values.rateLimit.policy.tokens.limit }}
+            unit: {{ .Values.rateLimit.policy.tokens.unit }}
+          cost:
+            request:
+              from: Number
+              number: 0   # the request itself costs 0 budget; only output tokens are charged
+            response:
+              from: Metadata
+              metadata:
+                namespace: io.envoy.ai_gateway
+                key: llm_output_token
+{{- end }}

--- a/sources/envoy-gateway-config/templates/ratelimit-redis.yaml
+++ b/sources/envoy-gateway-config/templates/ratelimit-redis.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.rateLimit.enabled }}
+# SPIKE (rate-limiting PoC): single ephemeral Redis backing Envoy Gateway's global
+# rate-limit service. NO persistence, NO HA — counters live in memory and reset if the
+# pod restarts. That is acceptable for the PoC (RL-1); the HA/persistence posture is an
+# explicit decision for RL-2 before this is relied upon.
+#
+# The EnvoyGateway control-plane config (root/values.yaml -> config.envoyGateway.rateLimit
+# .backend.redis.url) points at the Service below by DNS:
+#   ratelimit-redis.envoy-gateway-system.svc.cluster.local:6379
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratelimit-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ratelimit-redis
+    app.kubernetes.io/part-of: envoy-gateway
+    app.kubernetes.io/component: rate-limit-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratelimit-redis
+  template:
+    metadata:
+      labels:
+        app: ratelimit-redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.rateLimit.redis.image | quote }}
+          imagePullPolicy: IfNotPresent
+          args: ["--save", "", "--appendonly", "no"]  # disable persistence (ephemeral PoC)
+          ports:
+            - name: redis
+              containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratelimit-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ratelimit-redis
+    app.kubernetes.io/part-of: envoy-gateway
+    app.kubernetes.io/component: rate-limit-backend
+spec:
+  selector:
+    app: ratelimit-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+{{- end }}

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -24,3 +24,33 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
+
+# SPIKE (rate-limiting PoC, RL-1). Deploys an ephemeral Redis backing Envoy Gateway's
+# global rate-limit service and (optionally) a per-key BackendTrafficPolicy. The matching
+# EnvoyGateway control-plane switch lives in root/values.yaml
+# (config.envoyGateway.rateLimit.backend.redis.url -> ratelimit-redis Service below).
+rateLimit:
+  # Deploys ratelimit-redis (Deployment + Service). Required for any global rate limiting.
+  enabled: true
+  redis:
+    image: redis:7-alpine
+  # The actual per-key test policy. Left disabled by default so deploying the branch readies
+  # the infra without enforcing anything. Once we have a real API key on the cluster, set
+  # policy.enabled=true + policy.apiKeyId (and redeploy), OR kubectl-apply a filled copy of
+  # the rendered BackendTrafficPolicy directly for faster spike iteration.
+  policy:
+    enabled: false
+    # x-api-key-id value to limit (cluster-auth sets this = identity.Username for the key).
+    apiKeyId: ""
+    # What the policy attaches to. Default: the whole ai-gateway Gateway (simplest for the
+    # PoC); narrow to the per-service HTTPRoute later for true per-inference-service limits.
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ai-gateway
+    requests:
+      limit: 5
+      unit: Minute
+    tokens:
+      limit: 1000
+      unit: Minute


### PR DESCRIPTION
## What

Spike scaffolding (RL-1) to prove **native, per-API-key request + generation-token enforcement** on the AI gateway using Envoy Gateway global / cost-based rate limiting backed by Redis. No proxy or upstream code.

## Changes

| Change | File |
| --- | --- |
| Enable EG global rate-limit service, point it at in-cluster Redis | `root/values.yaml` (`config.envoyGateway.rateLimit.backend`) |
| Ephemeral Redis (Deployment + Service, no persistence/HA) | `sources/envoy-gateway-config/templates/ratelimit-redis.yaml` |
| Per-key `BackendTrafficPolicy` (request count + token budget) | `sources/envoy-gateway-config/templates/backend-traffic-policy-ratelimit.yaml` |
| Toggles + policy params | `sources/envoy-gateway-config/values.yaml` (`rateLimit.*`) |
| Runbook | `docs/rate-limit-spike.md` |

## Safe by default

- `rateLimit.enabled: true` → deploys Redis + the rate-limit service.
- `rateLimit.policy.enabled: false` → **the per-key policy does not render until a real key is supplied.**

So merging/deploying this **readies the infra and enforces nothing** — zero impact on inference until we plug in a key and flip the policy on.

## Builds on what's already live

- Token costs are emitted as `io.envoy.ai_gateway:llm_output_token` via `AIGatewayRoute.spec.llmRequestCosts` (ai-gateway-discovery).
- `x-api-key-id` is injected by cluster-auth ext_authz.

The policy keys on exactly those — this PR only adds the Redis backend + policy.

## Known risk to verify on cluster

The rate-limit filter must run **after** ext_authz or `x-api-key-id` is absent at limiting time. The ai-gateway EnvoyProxy already orders `lua before ext_authz`; live filter-chain ordering will be confirmed before enabling the policy (Step 2 in the runbook).

## Test plan

See `docs/rate-limit-spike.md`. Once deployed to app-dev with a real key:
1. >N requests/min → HTTP 429 after the limit.
2. Output tokens over budget → subsequent calls 429 (one-request overshoot, charged from prior response metadata).
3. A different key keeps working (per-key isolation).
4. Counts hold across Envoy replicas (shared Redis).

## Follow-ups (RL-2+)

Redis HA/persistence posture, windows offered (min/hour/day), confirm "generation tokens" = `llm_output_token` vs total, narrow `targetRef` to per-service HTTPRoute (or add `x-aim-service-id` selector) for per-inference-service limits.