### PR TITLE
Update envoy-gateway-config helm parameters

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -656,6 +656,8 @@ apps:
         value: "{{ .Values.global.domain }}"
       - name: aiGateway.enabled
         value: "true"  
+      - name: aiGateway.routeHostname
+        value: "ai.{{ .Values.global.domain }}"
     namespace: envoy-gateway-system
     path: envoy-gateway-config
     syncWave: -15


### PR DESCRIPTION
This PR adds a helm parameter at "envoy-gateway-config" to bring "ai-passthrough listener" for https and "ai-gateway-passthrough TLSRoute"