### PR TITLE
Allow Envoy Gateway to use cloud LoadBalancer providers and be deployed in arbitrary clusters

### DIFF
--- a/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
+++ b/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
@@ -19,8 +19,10 @@ spec:
         type: ClusterIP
       envoyDeployment:
         pod:
+          {{- if .Values.aiGateway.nodeSelector }}
           nodeSelector:
-            cluster-bloom/first-node: "true"
+            {{- toYaml .Values.aiGateway.nodeSelector | nindent 12 }}
+          {{- end }}
           priorityClassName: "system-cluster-critical"
   telemetry:
     accessLog:

--- a/sources/envoy-gateway-config/templates/coredns-config.yaml
+++ b/sources/envoy-gateway-config/templates/coredns-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rkeCoreDNS.enabled }}
 # CoreDNS Configuration for Wildcard Domain Routing
 # Copied from kgateway-config with service reference update
 # Makes *.domain resolve to envoy-gateway service
@@ -35,3 +36,4 @@ spec:
         - name: loop
         - name: reload
         - name: loadbalance
+{{- end }}

--- a/sources/envoy-gateway-config/templates/envoy-proxy-access-logs.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-proxy-access-logs.yaml
@@ -13,6 +13,14 @@ spec:
     type: Kubernetes
     kubernetes:
       envoyService:
+        {{- if .Values.appsGateway.envoyServiceAnnotations }}
+        annotations:
+          {{- toYaml .Values.appsGateway.envoyServiceAnnotations | nindent 10 }}
+        {{- end }}
+        {{- if .Values.appsGateway.envoyServicePatch }}
+        patch:
+          {{- toYaml .Values.appsGateway.envoyServicePatch | nindent 10 }}
+        {{- end }}
         # LoadBalancer: the apps gateway is the external front door and owns the VIP on :443
         # (HTTPS terminate + k8s TLS-passthrough listeners).
         type: {{ .Values.appsGateway.serviceType }}

--- a/sources/envoy-gateway-config/templates/envoy-proxy-access-logs.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-proxy-access-logs.yaml
@@ -18,8 +18,10 @@ spec:
         type: {{ .Values.appsGateway.serviceType }}
       envoyDeployment:
         pod:
+          {{- if .Values.appsGateway.nodeSelector }}
           nodeSelector:
-            cluster-bloom/first-node: "true"
+            {{- toYaml .Values.appsGateway.nodeSelector | nindent 12 }}
+          {{- end }}
           priorityClassName: "system-cluster-critical"
   telemetry:
     accessLog:

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -10,6 +10,8 @@ appsGateway:
   serviceType: LoadBalancer
   nodeSelector:
     cluster-bloom/first-node: "true"
+  envoyServiceAnnotations:
+  envoyServicePatch:
 
 # Stable ClusterIP `https` selecting the apps-gateway data plane, used by CoreDNS for the
 # *.domain rewrite (in-cluster resolution).

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -8,6 +8,8 @@ ports:
 # on the same :443 VIP by SNI. No separate tls-passthrough gateway.
 appsGateway:
   serviceType: LoadBalancer
+  nodeSelector:
+    cluster-bloom/first-node: "true"
 
 # Stable ClusterIP `https` selecting the apps-gateway data plane, used by CoreDNS for the
 # *.domain rewrite (in-cluster resolution).
@@ -27,6 +29,8 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
+  nodeSelector:
+    cluster-bloom/first-node: "true"
 
 # Configure RKE2 CoreDNS for Wilcdcard Domain Routing by making *.domain resolve to
 # envoy-gateway service

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -27,3 +27,8 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
+
+# Configure RKE2 CoreDNS for Wilcdcard Domain Routing by making *.domain resolve to
+# envoy-gateway service
+rkeCoreDNS:
+  enabled: true


### PR DESCRIPTION
In Kubernetes clusters containing cloud-specific providers for provisioning LoadBalancers instead of the default MetalLB provider, modifications to the LoadBalancer service deployed by EnvoyProxy are often required. To accommodate these requirements this change
- Exposes `kuberentes.envoyService.annotations` to allow injecting provider specific annotations
- For load balancer providers which still rely on the deprecated Service spec.loadBalancerIP field (e.g Openstack CCM), exposes EnvoyProxy `kubernetes.envoyService.patch` to make arbitrary patches to the underlying Service manifest

Also makes RKE2 and cluster-bloom specific config optional to allow envoy-gateway-config to be deployed in existing clusters where routing config for loadbalancing is handled elsewhere