### PR TITLE
fix via feature: add retry policy to cluster-apps.yaml template

### DIFF
--- a/root/templates/cluster-apps.yaml
+++ b/root/templates/cluster-apps.yaml
@@ -115,6 +115,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: {{ .syncRetryLimit | default 20 }}
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/sources/amd-gpu-operator-config/v1.4.1/templates/deviceconfig-example.yaml
+++ b/sources/amd-gpu-operator-config/v1.4.1/templates/deviceconfig-example.yaml
@@ -5,6 +5,10 @@ metadata:
   name: gpu-operator
   # it is highly recommended to use the namespace where AMD GPU Operator is running
   namespace: {{ .Release.Namespace }}
+  annotations:
+    # Avoid a hard sync failure when the amd-gpu-operator has not yet registered
+    # the DeviceConfig CRD; ArgoCD retries this app until the CRD is established.
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   driver:
     # set to ture for deploying out-of-tree driver with specified ROCm version 

--- a/sources/amd-gpu-operator-config/v1.5.1-beta.0/templates/deviceconfig.yaml
+++ b/sources/amd-gpu-operator-config/v1.5.1-beta.0/templates/deviceconfig.yaml
@@ -3,6 +3,10 @@ kind: DeviceConfig
 metadata:
   name: gpu-operator
   namespace: {{ .Release.Namespace }}
+  annotations:
+    # Avoid a hard sync failure when the amd-gpu-operator has not yet registered
+    # the DeviceConfig CRD; ArgoCD retries this app until the CRD is established.
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   configManager:
     enable: false


### PR DESCRIPTION
fix via feature: add retry policy to cluster-apps.yaml template
additionally add argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true (clean retry over hard error)