### PR TITLE
EAI-7304: default-deny backstop on ai-gateway

### DIFF
--- a/sources/envoy-ai-gateway/v0.6.0/values.yaml
+++ b/sources/envoy-ai-gateway/v0.6.0/values.yaml
@@ -74,13 +74,8 @@ controller:
   # Format: "header1:attribute1,header2:attribute2"
   # Example: "x-tenant-id:tenant.id"
   # x-api-key-id is injected by the SecurityPolicy apiKeyAuth (matched Secret data key = client ID).
-  # x-ai-eg-backend is the deployment/workload-id UUID the client sends for precise routing
-  # (== the AIMService id AIWB indexes on); captured as aim_service_id for per-model attribution.
-  # It must be a real request header (present at header phase) — the body->header Lua sets it
-  # too late for metric capture, so body-only callers are attributed to the key totals but not
-  # per-model. cluster-auth previously injected x-aim-service-id server-side via ext_authz; with
-  # cluster-auth off the ai-gateway we attribute by the client-sent x-ai-eg-backend instead.
-  requestHeaderAttributes: "x-api-key-id:api_key_id,x-ai-eg-backend:aim_service_id"
+  # x-aim-service-id is injected by headerMutation on each AIGatewayRoute backendRef.
+  requestHeaderAttributes: "x-api-key-id:api_key_id,x-aim-service-id:aim_service_id"
 
   # Comma-separated key-value pairs for mapping HTTP request headers to otel span attributes.
   # Format: "header1:attribute1,header2:attribute2"
@@ -92,7 +87,7 @@ controller:
   # Comma-separated key-value pairs for mapping HTTP request headers to Otel metric attributes.
   # Format: "header1:label1,header2:label2"
   # Example: "x-tenant-id:tenant.id,x-tenant-id:tenant.id"
-  metricsRequestHeaderAttributes: "x-api-key-id:api_key_id,x-ai-eg-backend:aim_service_id"
+  metricsRequestHeaderAttributes: "x-api-key-id:api_key_id,x-aim-service-id:aim_service_id"
 
   # Comma-separated key-value pairs for mapping HTTP request headers to access log attributes.
   # Format: "header1:attribute1,header2:attribute2"

--- a/sources/envoy-ai-gateway/v0.6.0/values.yaml
+++ b/sources/envoy-ai-gateway/v0.6.0/values.yaml
@@ -74,8 +74,13 @@ controller:
   # Format: "header1:attribute1,header2:attribute2"
   # Example: "x-tenant-id:tenant.id"
   # x-api-key-id is injected by the SecurityPolicy apiKeyAuth (matched Secret data key = client ID).
-  # x-aim-service-id is injected by headerMutation on each AIGatewayRoute backendRef.
-  requestHeaderAttributes: "x-api-key-id:api_key_id,x-aim-service-id:aim_service_id"
+  # x-ai-eg-backend is the deployment/workload-id UUID the client sends for precise routing
+  # (== the AIMService id AIWB indexes on); captured as aim_service_id for per-model attribution.
+  # It must be a real request header (present at header phase) — the body->header Lua sets it
+  # too late for metric capture, so body-only callers are attributed to the key totals but not
+  # per-model. cluster-auth previously injected x-aim-service-id server-side via ext_authz; with
+  # cluster-auth off the ai-gateway we attribute by the client-sent x-ai-eg-backend instead.
+  requestHeaderAttributes: "x-api-key-id:api_key_id,x-ai-eg-backend:aim_service_id"
 
   # Comma-separated key-value pairs for mapping HTTP request headers to otel span attributes.
   # Format: "header1:attribute1,header2:attribute2"
@@ -87,7 +92,7 @@ controller:
   # Comma-separated key-value pairs for mapping HTTP request headers to Otel metric attributes.
   # Format: "header1:label1,header2:label2"
   # Example: "x-tenant-id:tenant.id,x-tenant-id:tenant.id"
-  metricsRequestHeaderAttributes: "x-api-key-id:api_key_id,x-aim-service-id:aim_service_id"
+  metricsRequestHeaderAttributes: "x-api-key-id:api_key_id,x-ai-eg-backend:aim_service_id"
 
   # Comma-separated key-value pairs for mapping HTTP request headers to access log attributes.
   # Format: "header1:attribute1,header2:attribute2"

--- a/sources/envoy-ai-gateway/v0.6.0/values.yaml
+++ b/sources/envoy-ai-gateway/v0.6.0/values.yaml
@@ -74,8 +74,12 @@ controller:
   # Format: "header1:attribute1,header2:attribute2"
   # Example: "x-tenant-id:tenant.id"
   # x-api-key-id is injected by the SecurityPolicy apiKeyAuth (matched Secret data key = client ID).
-  # x-aim-service-id is injected by headerMutation on each AIGatewayRoute backendRef.
-  requestHeaderAttributes: "x-api-key-id:api_key_id,x-aim-service-id:aim_service_id"
+  # x-ai-eg-backend is the client-sent deployment/workload-id UUID used for precise routing
+  # (== the AIMService id used by the GPU/vLLM metrics, the /inference/{id} API, and AIWB URLs);
+  # captured as aim_service_id so token usage attributes per-deployment consistently with the rest
+  # of the product. Must be a real request header (present at header phase) — the body->header Lua
+  # sets it too late for metric capture, so body-only callers land in key totals but not per-model.
+  requestHeaderAttributes: "x-api-key-id:api_key_id,x-ai-eg-backend:aim_service_id"
 
   # Comma-separated key-value pairs for mapping HTTP request headers to otel span attributes.
   # Format: "header1:attribute1,header2:attribute2"
@@ -87,7 +91,7 @@ controller:
   # Comma-separated key-value pairs for mapping HTTP request headers to Otel metric attributes.
   # Format: "header1:label1,header2:label2"
   # Example: "x-tenant-id:tenant.id,x-tenant-id:tenant.id"
-  metricsRequestHeaderAttributes: "x-api-key-id:api_key_id,x-aim-service-id:aim_service_id"
+  metricsRequestHeaderAttributes: "x-api-key-id:api_key_id,x-ai-eg-backend:aim_service_id"
 
   # Comma-separated key-value pairs for mapping HTTP request headers to access log attributes.
   # Format: "header1:attribute1,header2:attribute2"

--- a/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
+++ b/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
@@ -49,7 +49,7 @@ spec:
               llm_output_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
               llm_total_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"
               api_key_id: "%REQ(x-api-key-id)%"
-              aim_service_id: "%REQ(x-ai-eg-backend)%"
+              aim_service_id: "%REQ(x-aim-service-id)%"
           sinks:
             - type: File
               file:

--- a/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
+++ b/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
@@ -49,7 +49,7 @@ spec:
               llm_output_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
               llm_total_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"
               api_key_id: "%REQ(x-api-key-id)%"
-              aim_service_id: "%REQ(x-aim-service-id)%"
+              aim_service_id: "%REQ(x-ai-eg-backend)%"
           sinks:
             - type: File
               file:

--- a/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
@@ -7,12 +7,11 @@
 # over any catch-all rules in other HTTPRoutes, regardless of HTTPRoute creation order.
 # The model-name fallback rule has been removed — clients must supply a backend UUID.
 #
-# x-aim-service-id is also set from the backend UUID for per-model metric attribution
-# (envoy-ai-gateway maps x-aim-service-id -> the aim_service_id metric label). cluster-auth
-# used to inject this header from the cluster-auth/aim-service-id route annotation; with
-# cluster-auth off ai-gateway (native apiKeyAuth cutover) nothing set it, so the per-model
-# usage graphs went empty. Keying on the workload-id UUID (same value as x-ai-eg-backend
-# and the aim-keys-<workload-id> Secret) keeps attribution working without cluster-auth.
+# Per-model metric attribution (the aim_service_id label) is handled by capturing the
+# client-sent x-ai-eg-backend header directly — see requestHeaderAttributes /
+# metricsRequestHeaderAttributes in the envoy-ai-gateway chart. It is NOT done here: a
+# Lua that reads the body sets headers after the ext_proc has already snapshotted request
+# headers, so it can't feed a request-header metric attribute.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyExtensionPolicy
 metadata:
@@ -36,7 +35,6 @@ spec:
           local model = body_str:match('"model"%s*:%s*"([^"]+)"')
           if backend ~= nil then
             request_handle:headers():replace("x-ai-eg-backend", backend)
-            request_handle:headers():replace("x-aim-service-id", backend)
           end
           if model ~= nil then
             request_handle:headers():replace("x-ai-eg-model", model)

--- a/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
@@ -6,6 +6,13 @@
 # 3-condition UUID rule (Host + x-ai-eg-backend + x-ai-eg-model) wins by specificity
 # over any catch-all rules in other HTTPRoutes, regardless of HTTPRoute creation order.
 # The model-name fallback rule has been removed — clients must supply a backend UUID.
+#
+# x-aim-service-id is also set from the backend UUID for per-model metric attribution
+# (envoy-ai-gateway maps x-aim-service-id -> the aim_service_id metric label). cluster-auth
+# used to inject this header from the cluster-auth/aim-service-id route annotation; with
+# cluster-auth off ai-gateway (native apiKeyAuth cutover) nothing set it, so the per-model
+# usage graphs went empty. Keying on the workload-id UUID (same value as x-ai-eg-backend
+# and the aim-keys-<workload-id> Secret) keeps attribution working without cluster-auth.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyExtensionPolicy
 metadata:
@@ -29,6 +36,7 @@ spec:
           local model = body_str:match('"model"%s*:%s*"([^"]+)"')
           if backend ~= nil then
             request_handle:headers():replace("x-ai-eg-backend", backend)
+            request_handle:headers():replace("x-aim-service-id", backend)
           end
           if model ~= nil then
             request_handle:headers():replace("x-ai-eg-model", model)

--- a/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-extension-policy-model-header.yaml
@@ -6,12 +6,6 @@
 # 3-condition UUID rule (Host + x-ai-eg-backend + x-ai-eg-model) wins by specificity
 # over any catch-all rules in other HTTPRoutes, regardless of HTTPRoute creation order.
 # The model-name fallback rule has been removed — clients must supply a backend UUID.
-#
-# Per-model metric attribution (the aim_service_id label) is handled by capturing the
-# client-sent x-ai-eg-backend header directly — see requestHeaderAttributes /
-# metricsRequestHeaderAttributes in the envoy-ai-gateway chart. It is NOT done here: a
-# Lua that reads the body sets headers after the ext_proc has already snapshotted request
-# headers, so it can't feed a request-header metric attribute.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyExtensionPolicy
 metadata:

--- a/sources/envoy-gateway-config/templates/envoy-proxy-access-logs.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-proxy-access-logs.yaml
@@ -48,7 +48,7 @@ spec:
               llm_output_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
               llm_total_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"
               api_key_id: "%REQ(x-api-key-id)%"
-              aim_service_id: "%REQ(x-ai-eg-backend)%"
+              aim_service_id: "%REQ(x-aim-service-id)%"
           sinks:
             - type: File
               file:

--- a/sources/envoy-gateway-config/templates/envoy-proxy-access-logs.yaml
+++ b/sources/envoy-gateway-config/templates/envoy-proxy-access-logs.yaml
@@ -48,7 +48,7 @@ spec:
               llm_output_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_output_token)%"
               llm_total_token: "%DYNAMIC_METADATA(io.envoy.ai_gateway:llm_total_token)%"
               api_key_id: "%REQ(x-api-key-id)%"
-              aim_service_id: "%REQ(x-aim-service-id)%"
+              aim_service_id: "%REQ(x-ai-eg-backend)%"
           sinks:
             - type: File
               file:

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.aiGateway.enabled .Values.aiGateway.nativeAuth.enabled }}
+# Gateway-scoped default-deny backstop for the `ai-gateway` Gateway (EAI-7304 cutover).
+#
+# Only model routes ride ai-gateway, so a blanket deny is safe here (unlike the shared
+# `https` gateway, whose model-route deny is route-scoped and owned by aim-engine / EAI-7302).
+# Any request whose HTTPRoute has no per-model apiKeyAuth SecurityPolicy — a keyless/opted-out
+# model, or a header-less/unmatched request — is refused, instead of falling through
+# unauthenticated once cluster-auth ext_authz is removed from this Gateway
+# (see security-policy-extauth.yaml, which drops its ai-gateway targetRef under the same switch).
+#
+# Per-model apiKeyAuth SecurityPolicies from ai-gateway-discovery target individual HTTPRoutes;
+# a route-level SecurityPolicy overrides this gateway-level one for that route (Envoy Gateway
+# resolves by specificity, no merge), so keyed models authenticate and keyless ones hit deny.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: ai-gateway-default-deny
+  namespace: envoy-gateway-system  # must match the ai-gateway Gateway's namespace
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ai-gateway
+  authorization:
+    # No rules → every request on ai-gateway not overridden by a route-level policy is denied.
+    defaultAction: Deny
+{{- end }}

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.aiGateway.enabled .Values.aiGateway.nativeAuth.enabled }}
+{{- if .Values.aiGateway.enabled }}
 # Gateway-scoped default-deny backstop for the `ai-gateway` Gateway (EAI-7304 cutover).
 #
 # Only model routes ride ai-gateway, so a blanket deny is safe here (unlike the shared

--- a/sources/envoy-gateway-config/templates/security-policy-extauth.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-extauth.yaml
@@ -7,20 +7,15 @@ metadata:
   name: cluster-auth-extauth-policy
   namespace: envoy-gateway-system  # Envoy Gateway namespace
 spec:
-  # Targets `https` always. Also targets `ai-gateway` UNTIL the native-auth cutover:
-  # when aiGateway.nativeAuth.enabled is true, ai-gateway is handed to the gateway-scoped
-  # default-deny SecurityPolicy (security-policy-ai-gateway-default-deny.yaml) and dropped
-  # here — two gateway-scoped SecurityPolicies cannot target the same Gateway, so the flip
-  # is atomic via that one values switch.
+  # cluster-auth ext_authz targets `https` only. ai-gateway is enforced natively by
+  # per-model apiKeyAuth policies (ai-gateway-discovery) plus the gateway-scoped
+  # default-deny backstop (security-policy-ai-gateway-default-deny.yaml) — two
+  # gateway-scoped SecurityPolicies cannot target the same Gateway, so ext_authz never
+  # targets ai-gateway.
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: https
-{{- if and .Values.aiGateway.enabled (not .Values.aiGateway.nativeAuth.enabled) }}
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: ai-gateway
-{{- end }}
 
   # External Authorization configuration (matches current kgateway GatewayExtension)
   extAuth:

--- a/sources/envoy-gateway-config/templates/security-policy-extauth.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-extauth.yaml
@@ -7,14 +7,16 @@ metadata:
   name: cluster-auth-extauth-policy
   namespace: envoy-gateway-system  # Envoy Gateway namespace
 spec:
-  # Target both gateways for global-like behavior: apps on `https`, AI on `ai-gateway`.
-  # The AI auth chain (set-model-header-from-body -> ext_authz) runs on `ai-gateway`, where
-  # AI traffic terminates after the apps gateway passes it through by SNI.
+  # Targets `https` always. Also targets `ai-gateway` UNTIL the native-auth cutover:
+  # when aiGateway.nativeAuth.enabled is true, ai-gateway is handed to the gateway-scoped
+  # default-deny SecurityPolicy (security-policy-ai-gateway-default-deny.yaml) and dropped
+  # here — two gateway-scoped SecurityPolicies cannot target the same Gateway, so the flip
+  # is atomic via that one values switch.
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: https
-{{- if .Values.aiGateway.enabled }}
+{{- if and .Values.aiGateway.enabled (not .Values.aiGateway.nativeAuth.enabled) }}
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: ai-gateway

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -18,6 +18,13 @@ gatewayDnsService:
 # isolating inference/EPP failures from the apps gateway (EAI-6805). The apps gateway TLS-
 # passes-through routeHostname to it by SNI and ai-gateway terminates its own TLS. AI routes
 # land here once ai-gateway-discovery targets it (GATEWAY_NAME=ai-gateway, in silogen/core).
+# Enabling ai-gateway IS the native apiKeyAuth cutover for it (EAI-7304): ai-gateway is
+# backstopped by a gateway-scoped default-deny SecurityPolicy (any model route without a
+# per-model apiKeyAuth policy from ai-gateway-discovery is refused, not passed through
+# unauthenticated), and cluster-auth ext_authz is removed from ai-gateway (it stays on
+# `https`). So only enable it once every model on ai-gateway is natively enforced — the
+# ai-gateway-discovery controller (always-on enforcement) is deployed and keys are
+# populated (aim-keys-<workload-id> Secrets exist) — or keyed model traffic is denied.
 aiGateway:
   enabled: false
   # SNI host the apps gateway passes through to ai-gateway. MUST equal the discovery
@@ -27,12 +34,3 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
-  # Native per-model apiKeyAuth cutover for ai-gateway (EAI-7304). When true:
-  #   - ai-gateway is backstopped by a gateway-scoped default-deny SecurityPolicy, so any
-  #     model route without a per-model apiKeyAuth policy (from ai-gateway-discovery) is
-  #     refused instead of falling through unauthenticated, and
-  #   - cluster-auth ext_authz is removed from the ai-gateway Gateway (it stays on `https`).
-  # Requires enabled: true. Keep false until every model on ai-gateway is natively enforced
-  # (ai-gateway-discovery API_KEY_AUTH_ENABLED on); flipping it is the ai-gateway cutover.
-  nativeAuth:
-    enabled: false

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -27,3 +27,12 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
+  # Native per-model apiKeyAuth cutover for ai-gateway (EAI-7304). When true:
+  #   - ai-gateway is backstopped by a gateway-scoped default-deny SecurityPolicy, so any
+  #     model route without a per-model apiKeyAuth policy (from ai-gateway-discovery) is
+  #     refused instead of falling through unauthenticated, and
+  #   - cluster-auth ext_authz is removed from the ai-gateway Gateway (it stays on `https`).
+  # Requires enabled: true. Keep false until every model on ai-gateway is natively enforced
+  # (ai-gateway-discovery API_KEY_AUTH_ENABLED on); flipping it is the ai-gateway cutover.
+  nativeAuth:
+    enabled: false


### PR DESCRIPTION
## What

Adds the **ai-gateway** half of the cluster-auth → native `apiKeyAuth` cutover (EAI-7304): a gateway-scoped default-deny backstop, behind a single values switch, off by default.

- **New** `security-policy-ai-gateway-default-deny.yaml` — a `SecurityPolicy` with `authorization.defaultAction: Deny` targeting the `ai-gateway` Gateway. Only model routes ride `ai-gateway`, so a blanket deny is safe: any route without a per-model `apiKeyAuth` policy (from `ai-gateway-discovery`) — a keyless/opted-out model, or a header-less/unmatched request — is refused instead of falling through unauthenticated.
- **`security-policy-extauth.yaml`** — drops its `ai-gateway` targetRef when the switch is on (two gateway-scoped SecurityPolicies can't target the same Gateway), so the flip is atomic. cluster-auth ext_authz stays on `https`.
- **`values.yaml`** — new `aiGateway.nativeAuth.enabled` (default `false`).

## Behaviour by state (verified with `helm template`)

| State | `cluster-auth-extauth-policy` | `ai-gateway-default-deny` |
|---|---|---|
| default (`aiGateway.enabled=false`) | → `https` | not rendered |
| ai-gateway on, pre-cutover | → `https` + `ai-gateway` | not rendered |
| cutover (`nativeAuth.enabled=true`) | → `https` only | → `ai-gateway`, `Deny` |

Route-level per-model `apiKeyAuth` policies override this gateway-level deny for their route, so keyed models authenticate and keyless ones hit deny.

## Deploy ordering ⚠️

Flipping `aiGateway.nativeAuth.enabled: true` makes the deny active, so **every ai-gateway model route without a per-model apiKeyAuth policy is 403'd**. Ensure `ai-gateway-discovery` has `API_KEY_AUTH_ENABLED` on (enforcement) **first**, so keyed models already carry their policies — otherwise all ai-gateway traffic is denied, not just keyless models.

## Scope

ai-gateway only. The `https` workloads-route deny is route-scoped and owned by aim-engine (EAI-7302); actual cluster-auth removal/decommission is EAI-7305 (P3.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)