### PR TITLE
Backport v2.2.1 chart bumps (aiwb/airm 2.0.1) to main

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -10,7 +10,7 @@ global:
   clusterSize:    # injected via scripts/bootstrap.sh
   domain:         # injected via scripts/bootstrap.sh
 ociRegistry:
-  dockerHub: "registry-1.docker.io/amdenterpriseai"
+  dockerHub: "registry-1.docker.io/silogenai"
   ghcr: "ghcr.io/silogen"
 
 apps:

--- a/root/values.yaml
+++ b/root/values.yaml
@@ -10,13 +10,13 @@ global:
   clusterSize:    # injected via scripts/bootstrap.sh
   domain:         # injected via scripts/bootstrap.sh
 ociRegistry:
-  dockerHub: "registry-1.docker.io/silogenai"
+  dockerHub: "registry-1.docker.io/amdenterpriseai"
   ghcr: "ghcr.io/silogen"
 
 apps:
   ai-gateway-discovery:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.1-rc.2"
+    repoVersion: "2.0.1"
     chart: "ai-gateway-discovery-chart"
     namespace: ai-gateway-system
     valuesFile: values.yaml
@@ -50,7 +50,7 @@ apps:
       hardwareFamilies: []
   airm:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.1-rc.2"
+    repoVersion: "2.0.0"
     chart: "airm-chart"
     namespace: airm
     syncWave: 0
@@ -67,7 +67,7 @@ apps:
         kind: ClusterPolicy
   aiwb:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.1-rc.2"
+    repoVersion: "2.0.1"
     chart: "aiwb-chart"
     namespace: aiwb
     valuesFile: values.yaml
@@ -82,14 +82,14 @@ apps:
           - /spec/rules/*/skipBackgroundRequests
   airm-infra-cnpg:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.1-rc.2"
+    repoVersion: "2.0.0"
     chart: "airm-cnpg-chart"
     namespace: airm
     syncWave: -10
     valuesFile: values.yaml
   airm-infra-external-secrets:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.1-rc.2"
+    repoVersion: "2.0.0"
     chart: "airm-external-secrets-chart"
     namespace: airm
     syncWave: -20
@@ -103,21 +103,21 @@ apps:
           - ".spec.data[].remoteRef.metadataPolicy"
   airm-infra-rabbitmq:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.1-rc.2"
+    repoVersion: "2.0.0"
     chart: "airm-rabbitmq-chart"
     namespace: airm
     syncWave: -5
     valuesFile: values.yaml
   aiwb-infra-cnpg:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.1-rc.2"
+    repoVersion: "2.0.1"
     chart: "aiwb-cnpg-chart"
     namespace: aiwb
     syncWave: -10
     valuesFile: values.yaml
   aiwb-infra-external-secrets:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.1-rc.2"
+    repoVersion: "2.0.1"
     chart: "aiwb-external-secrets-chart"
     namespace: aiwb
     syncWave: -20

--- a/root/values.yaml
+++ b/root/values.yaml
@@ -16,7 +16,7 @@ ociRegistry:
 apps:
   ai-gateway-discovery:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.0"
+    repoVersion: "2.0.1-rc.2"
     chart: "ai-gateway-discovery-chart"
     namespace: ai-gateway-system
     valuesFile: values.yaml
@@ -50,7 +50,7 @@ apps:
       hardwareFamilies: []
   airm:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.0"
+    repoVersion: "2.0.1-rc.2"
     chart: "airm-chart"
     namespace: airm
     syncWave: 0
@@ -67,7 +67,7 @@ apps:
         kind: ClusterPolicy
   aiwb:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.0"
+    repoVersion: "2.0.1-rc.2"
     chart: "aiwb-chart"
     namespace: aiwb
     valuesFile: values.yaml
@@ -82,14 +82,14 @@ apps:
           - /spec/rules/*/skipBackgroundRequests
   airm-infra-cnpg:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.0"
+    repoVersion: "2.0.1-rc.2"
     chart: "airm-cnpg-chart"
     namespace: airm
     syncWave: -10
     valuesFile: values.yaml
   airm-infra-external-secrets:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.0"
+    repoVersion: "2.0.1-rc.2"
     chart: "airm-external-secrets-chart"
     namespace: airm
     syncWave: -20
@@ -103,21 +103,21 @@ apps:
           - ".spec.data[].remoteRef.metadataPolicy"
   airm-infra-rabbitmq:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.0"
+    repoVersion: "2.0.1-rc.2"
     chart: "airm-rabbitmq-chart"
     namespace: airm
     syncWave: -5
     valuesFile: values.yaml
   aiwb-infra-cnpg:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.0"
+    repoVersion: "2.0.1-rc.2"
     chart: "aiwb-cnpg-chart"
     namespace: aiwb
     syncWave: -10
     valuesFile: values.yaml
   aiwb-infra-external-secrets:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
-    repoVersion: "2.0.0"
+    repoVersion: "2.0.1-rc.2"
     chart: "aiwb-external-secrets-chart"
     namespace: aiwb
     syncWave: -20


### PR DESCRIPTION
## Summary

Brings the 4 commits from the `v2-2-1-rc` release branch (tagged `v2.2.1` / `v2.2.1-rc1` at `424a845`) onto `main`. These were tagged off the RC branch and never merged back, so `main` was missing the chart version bumps.

Cherry-picked commits (original authorship preserved):
- `chore: bump airm/aiwb chart versions to 2.0.1-rc.2 for EAI 2.2.1 patch RC`
- `Update values.yaml - update ociRegistry dockerHub value`
- `load charts from amdenterpriseai, update versions of aiwb and airm`
- `fix: trigger changes`

## Net effect

`root/values.yaml`: bump `repoVersion` `2.0.0` → `2.0.1` for `ai-gateway-discovery`, `aiwb`, `aiwb-infra-cnpg`, `aiwb-infra-external-secrets`. Resulting file is identical to the `v2-2-1-rc` tip.

## Test plan

- [ ] Confirm chart versions `2.0.1` exist in the registry
- [ ] ArgoCD sync validates against bumped versions

Made with [Cursor](https://cursor.com)