### PR TITLE
EAI-7277: scoped OpenBao write credential for the API-key KV path

### DIFF
--- a/sources/eai-infra/aiwb-external-secrets/0.1.2/templates/external-secrets.yaml
+++ b/sources/eai-infra/aiwb-external-secrets/0.1.2/templates/external-secrets.yaml
@@ -132,6 +132,28 @@ spec:
     name: {{ .Values.frontend.nextAuthSecretName }}
     template:
       type: Opaque
+---
+# Scoped OpenBao write token for the API-key KV path (EAI-7277 / P0.3). Provisioned in OpenBao
+# by the secret-manager (policy apikeys-write-policy, token at secrets/aiwb-openbao-token) and
+# consumed by the AIWB backend as OPENBAO_TOKEN for the ADR-0002 Scenario 2 key store.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.openbaoToken.secretName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  data:
+    - remoteRef:
+        key: aiwb-openbao-token
+        property: value
+      secretKey: value
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.externalSecretStore }}
+  target:
+    name: {{ .Values.openbaoToken.secretName }}
+    template:
+      type: Opaque
 
 # =============================================================================
 # Standalone mode secrets (only when not integrated with AIRM)

--- a/sources/eai-infra/aiwb-external-secrets/0.1.2/values.yaml
+++ b/sources/eai-infra/aiwb-external-secrets/0.1.2/values.yaml
@@ -30,6 +30,11 @@ minio:
 clusterAuth:
   secretName: "cluster-auth-admin-token"
 
+# Scoped OpenBao write token for the API-key KV path (EAI-7277). Consumed by the AIWB backend
+# as OPENBAO_TOKEN; must match openBao.secretName in the core aiwb chart.
+openbaoToken:
+  secretName: "aiwb-openbao-token"
+
 # PostgreSQL CNPG Configuration
 postgresql:
   username: "aiwb_user"

--- a/sources/openbao-config/0.1.0/templates/openbao-secret-definitions.yaml
+++ b/sources/openbao-config/0.1.0/templates/openbao-secret-definitions.yaml
@@ -139,7 +139,11 @@ data:
 
     # Cluster auth OpenBao token (will be set to actual BAO_TOKEN)
     # Note: This is handled specially in the script
-    
+
+    # AIWB scoped API-key write token (secrets/aiwb-openbao-token)
+    # Note: minted specially in the script (bao token create, scoped to apikeys-write-policy);
+    # it is a token, not a static/random KV value, so it is not a definitions row here.
+
     # =============================================================================
     # ADD NEW SECRETS BELOW THIS LINE
     # =============================================================================

--- a/sources/openbao-config/0.1.0/templates/openbao-secret-manager-cm.yaml
+++ b/sources/openbao-config/0.1.0/templates/openbao-secret-manager-cm.yaml
@@ -62,7 +62,37 @@ data:
     done < /tmp/secrets/secrets.env
 
     echo "DONE: Created $created, Updated $updated, Skipped $skipped"
-    
+
+    # AIWB scoped API-key write credential (EAI-7277). Unlike cluster-auth (which reuses the
+    # root token), AIWB gets a token scoped to secrets/apikeys/* so it cannot write elsewhere.
+    # No renewal machinery: re-mint only when the stored token is absent or no longer valid.
+    # Capabilities match the AIWB OpenBao client — data create/read/update, metadata
+    # create/update (delete_version_after / native expiry) and delete (revocation).
+    echo "Ensuring apikeys-write-policy..."
+    echo '
+    path "secrets/data/apikeys/*" {
+      capabilities = ["create", "read", "update"]
+    }
+    path "secrets/metadata/apikeys/*" {
+      capabilities = ["create", "read", "update", "delete"]
+    }
+    path "auth/token/lookup-self" {
+      capabilities = ["read"]
+    }' | bao policy write apikeys-write-policy -
+
+    need_mint=true
+    if stored=$(bao kv get -field=value secrets/aiwb-openbao-token 2>/dev/null); then
+      if BAO_TOKEN="$stored" bao token lookup >/dev/null 2>&1; then
+        need_mint=false
+        echo "SKIP: secrets/aiwb-openbao-token (scoped token still valid)"
+      fi
+    fi
+    if [ "$need_mint" = "true" ]; then
+      echo "MINT: secrets/aiwb-openbao-token (scoped apikeys-write token)"
+      new_token=$(bao token create -policy=apikeys-write-policy -ttl=768h -orphan -field=token) || { echo "ERROR: Failed to mint aiwb-openbao-token"; exit 1; }
+      bao kv put secrets/aiwb-openbao-token value="$new_token" || { echo "ERROR: Failed to store aiwb-openbao-token"; exit 1; }
+    fi
+
     # Special case: cluster-auth-openbao-token uses actual BAO_TOKEN (for init job only)
     if [ "$INIT_MODE" = "true" ]; then
       echo "CREATE: secrets/cluster-auth-openbao-token (special - init mode)"


### PR DESCRIPTION
## Summary
Adds a scoped OpenBao write credential for AIWB's API-key KV path (`secrets/apikeys/*`), so AIWB can store API-key tokens without reusing the root token. Foundation only — this does not touch, replace, or bypass cluster-auth (that's the later cutover: EAI-7303/7304/7305).

Scoped rather than reusing the root token like cluster-auth, so a compromise of AIWB can't read/write the rest of `secrets/*`.

- **`openbao-config`** — the secret-manager now ensures an `apikeys-write-policy` and mints a token at `secrets/aiwb-openbao-token`, re-minting only when the stored one is missing or invalid. Policy grants `secrets/data/apikeys/*` create/read/update and `secrets/metadata/apikeys/*` create/read/update/delete.
- **`aiwb-external-secrets`** — a new ExternalSecret materializes that token into the `aiwb` namespace as `aiwb-openbao-token`, which the AIWB backend consumes as `OPENBAO_TOKEN`.

## Test plan
**Verified locally:** `helm template` renders the new `aiwb-openbao-token` ExternalSecret; `bash -n` on the modified `manage-secrets.sh` passes.

**To verify on app-dev (not yet done):** `apikeys-write-policy` + `secrets/aiwb-openbao-token` exist; with that token, writes under `secrets/apikeys/*` succeed and writes elsewhere are refused; `delete_version_after` expiry works; ESO populates the `aiwb-openbao-token` Secret. (The `aiwb-external-secrets` half is inert until the infra chart is republished.)