### PR TITLE
docs: update 2.2.0 refs to 2.2.2 in migration from 2.1.x guide

### DIFF
--- a/docs/v2.1.x-to-v2.2-migration.md
+++ b/docs/v2.1.x-to-v2.2-migration.md
@@ -16,7 +16,7 @@
 While kgateway is **still live**. Copies the TLS secret and labels the first node.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/silogen/cluster-forge/v2.2.0/scripts/utils/envoy-gateway-migration.yaml
+kubectl apply -f https://raw.githubusercontent.com/silogen/cluster-forge/v2.2.2/scripts/utils/envoy-gateway-migration.yaml
 
 # Phase 1 — init container copies the TLS secret (watch this first):
 kubectl logs -f job/envoy-gateway-migration -n envoy-gateway-system -c tls-copy
@@ -37,7 +37,7 @@ Open Gitea → `cluster-org/cluster-values` → `values.yaml` → Edit. Make all
 **a) Bump the version:**
 ```yaml
 clusterForge:
-  targetRevision: v2.2.0
+  targetRevision: v2.2.2
 ```
 
 **b) Swap the app list** — under `enabledApps`, remove:
@@ -69,13 +69,13 @@ seaweedfs-crds, seaweedfs-operator, seaweedfs-config
 2. Click the **`cluster-forge`** application to open it.
 3. Click **Details** (top toolbar) → open the **Manifest** tab → click **EDIT**.
 4. Under `spec.sources`, find the source with **`path: root`** and change its
-   `targetRevision` to **`v2.2.0`**:
+   `targetRevision` to **`v2.2.2`**:
    ```yaml
    spec:
      sources:
        - repoURL: http://gitea-http.cf-gitea.svc:3000/cluster-org/cluster-forge.git
          path: root
-         targetRevision: v2.2.0      # <-- change this line
+         targetRevision: v2.2.2      # <-- change this line
          helm:
            valueFiles:
              - values.yaml
@@ -192,7 +192,7 @@ your hardware" banner.
 The job auto-discovers every bucket in MinIO and mirrors each to a same-named bucket in
 SeaweedFS — one apply does the whole migration:
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/silogen/cluster-forge/v2.2.0/scripts/utils/mirror-minio-to-seaweedfs-job.yaml
+kubectl apply -f https://raw.githubusercontent.com/silogen/cluster-forge/v2.2.2/scripts/utils/mirror-minio-to-seaweedfs-job.yaml
 kubectl logs -f job/minio-to-seaweedfs-mirror-job -n default
 ```
 ✅ Wait for **`Mirror operation completed successfully!`** (job self-deletes 5 min later).


### PR DESCRIPTION
docs: update 2.2.0 refs to 2.2.2 in migration from 2.1.x guide