### PR TITLE
Add option to use local Helm values for apps

### DIFF
--- a/root/templates/cluster-forge.yaml
+++ b/root/templates/cluster-forge.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if not .Values.localHelmValues.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -48,3 +49,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+{{- end }}

--- a/root/values.yaml
+++ b/root/values.yaml
@@ -9,6 +9,8 @@ externalValues:
 global:
   clusterSize:    # injected via scripts/bootstrap.sh
   domain:         # injected via scripts/bootstrap.sh
+localHelmValues:
+  enabled: false
 ociRegistry:
   dockerHub: "registry-1.docker.io/amdenterpriseai"
   ghcr: "ghcr.io/silogen"


### PR DESCRIPTION
Currently the only way override Helm values in a way that the changes won't be reverted by ArgoCD is to use externalValues and reference an external repository or the local Gitea server containing an overrides files. For local development or when consuming cluster-forge dependencies as part of a manual Helm installation of AIWB/AIRM where a Gitea server is not a hard dependency, it is useful to be able to iterate on the configuration purely through upgrading the Helm release rather than pushing commits to a remote repository.

Adds localHelmValues.enabled option which disables the cluster-forge wrapper Application. This allows the user to deploy cluster-forge with local overrides e.g with helm install cluster-forge ./root --values values_<size>.yaml --values custom_overrides.yaml while ArgoCD still consumes the remote OCI artifacts and defaults for each of the constituent applications for a given revision of cluster-forge.

Needs docs but the docs/configuration-reference.md files referenced in CONTRIBUTING.md seems to be missing so unsure where the best place for these would be.