### PR TITLE
EAI-7555_Overhaul_lgtm_stack

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -901,7 +901,7 @@ apps:
       - name: cluster.name
         value: "{{ .Values.global.domain }}"
     namespace: otel-lgtm-stack
-    path: otel-lgtm-stack/v1.0.7
+    path: otel-lgtm-stack/v1.0.8
     syncWave: -20
     valuesObject:
       cluster:

--- a/sbom/components.yaml
+++ b/sbom/components.yaml
@@ -299,7 +299,7 @@ components:
     license: Apache License 2.0
     licenseUrl: https://github.com/open-telemetry/opentelemetry-operator/blob/main/LICENSE
   otel-lgtm-stack:
-    path: otel-lgtm-stack/v1.0.7
+    path: otel-lgtm-stack/v1.0.8
     type: helm
     sourceUrl: https://github.com/silogen/docker-otel-lgtm
     projectUrl: https://github.com/grafana/docker-otel-lgtm

--- a/sources/otel-lgtm-stack/v1.0.8/Chart.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: otel-lgtm-stack
+description: A Helm chart for OpenTelemetry LGTM (Loki, Grafana, Tempo, Mimir) stack
+
+# A chart can be either an 'application' or a 'library' chart.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.8
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.8"

--- a/sources/otel-lgtm-stack/v1.0.8/templates/chrony-node-exporter.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/chrony-node-exporter.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nodeexporter-chrony-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: chrony-exporter
+spec:
+  selector:
+    matchLabels:
+      app: chrony-exporter
+  template:
+    metadata:
+      labels:
+        app: chrony-exporter
+    spec:
+      containers:
+        - name: chrony-exporter
+          image: quay.io/superq/chrony-exporter:v0.12.1
+          args:
+            - "--chrony.address=unix:///run/chrony/chronyd.sock"
+            - "--collector.chmod-socket"
+            - "--collector.sources"
+            - "--collector.tracking"
+            - "--log.level=info"
+          securityContext:
+            runAsUser: 0
+          ports:
+            - containerPort: 9123
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /run/chrony/
+              name: chronyd-socket
+          resources:
+            limits:
+              cpu: "100m"
+              memory: 128Mi
+            requests:
+              cpu: "50m"
+              memory: 64Mi
+      volumes:
+        - name: chronyd-socket
+          hostPath:
+            path: /run/chrony/
+            type: Directory

--- a/sources/otel-lgtm-stack/v1.0.8/templates/collectors-logs-metrics-k8s.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/collectors-logs-metrics-k8s.yaml
@@ -1,0 +1,725 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-logs
+  namespace: {{ .Release.Namespace }}
+spec:
+  mode: daemonset
+  serviceAccount: otel-collector
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0"
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  tolerations:
+        - effect: NoSchedule
+          key: exampleKey1
+          operator: Equal
+          value: "true"
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8888"
+  resources:
+    limits:
+      cpu: {{ .Values.collectors.resources.logs.limits.cpu | quote }}
+      memory: {{ .Values.collectors.resources.logs.limits.memory }}
+    requests:
+      cpu: {{ .Values.collectors.resources.logs.requests.cpu | quote }}
+      memory: {{ .Values.collectors.resources.logs.requests.memory }}
+  securityContext: ####
+    privileged: true
+    runAsUser: 0 ####
+    runAsGroup: 0 ####
+  config: ####
+    receivers:
+      filelog/std:
+        exclude:
+        - /var/log/pods/*/otel-collector/*.log
+        - /var/log/pods/*/otc-container/*.log
+        - /var/log/pods/*/openobserve-ingester/*.log
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          output: extract_metadata_from_filepath
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - id: parser-containerd
+          output: extract_metadata_from_filepath
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - id: parser-docker
+          output: extract_metadata_from_filepath
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - cache:
+            size: 128
+          id: extract_metadata_from_filepath
+          parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.log
+          to: body
+          type: move
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        start_at: end
+    processors:
+      attributes:
+        actions:
+          - key: k8s_cluster_name
+            action: insert
+            value: {{ .Values.cluster.name | quote }}
+      transform: ### this adds k8s.cluster.name as a label filter
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(resource.attributes["k8s.cluster.name"], attributes["k8s.cluster.name"])
+              - set(resource.attributes["component.id"], attributes["component.id"])
+              - set(resource.attributes["workload.id"], attributes["workload.id"])
+      batch:
+        send_batch_size: 2000
+        timeout: 10s
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          labels:
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: service.name
+          - from: pod
+            key: k8s-app
+            tag_name: service.name
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.app.instance
+          - from: pod
+            key: app.kubernetes.io/version
+            tag_name: service.version
+          - from: pod
+            key: app.kubernetes.io/component
+            tag_name: k8s.app.component
+          - from: pod
+            key: airm.silogen.ai/component-id
+            tag_name: component.id
+          - from: pod
+            key: airm.silogen.ai/workload-id
+            tag_name: workload.id
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+          - from: resource_attribute
+            name: k8s.node.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+        - sources:
+          - from: connection
+      resourcedetection:
+        detectors:
+        - env
+        override: true
+        timeout: 2s
+
+    extensions: ##
+      basicauth/loki-tenant:
+        client_auth:
+          username: loki_tenant_demo
+          password: loki-tenant-demo-password
+
+    exporters:
+      otlp:
+        endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
+        tls:
+          insecure: true
+
+      # Debug exporter - can remove in production
+      debug:
+        verbosity: detailed    
+
+    service:
+      extensions: [basicauth/loki-tenant]
+      pipelines:
+        logs:
+          receivers: [filelog/std]
+          processors: [batch, k8sattributes, attributes, transform]
+          exporters: [otlp]
+          #exporters: [otlp, debug]
+  volumes:
+    - name: varlog
+      hostPath:
+        path: /var/log
+        type: ''
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+        type: ''
+  volumeMounts:
+    - name: varlog
+      mountPath: /var/log
+    - name: varlibdockercontainers
+      readOnly: true
+      mountPath: /var/lib/docker/containers
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-logs-events
+  namespace: {{ .Release.Namespace }}
+spec:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0
+  mode: deployment
+  serviceAccount: otel-collector
+  config: 
+    receivers:
+      k8sobjects:
+        auth_type: serviceAccount
+        objects:
+          - name: events
+            mode: watch
+            group: events.k8s.io
+            exclude_watch_type: ["MODIFIED", "DELETED", "BOOKMARK"]
+            interval: 30s
+    processors:
+      attributes:
+        actions:
+          - key: log_type
+            action: insert
+            value: "k8s_event"
+
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          labels:
+          - from: pod
+            key: airm.silogen.ai/component-id
+            tag_name: component.id
+          - from: pod
+            key: airm.silogen.ai/workload-id
+            tag_name: workload.id
+          # Extract annotations that might help identify related resources 
+          annotations:
+          - from: pod
+            key: airm.silogen.ai/workload-id
+            tag_name: workload.id.annotation
+          metadata: 
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.job.name
+          - k8s.job.uid
+        passthrough: false
+        # For events: the k8sobjects receiver sets k8s.object.kind, k8s.object.name, k8s.namespace.name
+        # Pod association will only work for events directly about pods
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+
+      # Filter processor to drop events with empty notes
+      filter/non-empty-note:
+        error_mode: ignore
+        logs:
+          log_record:
+            - '(body["object"]["note"] != nil and body["object"]["note"] != "") or (body["object"]["message"] != nil and body["object"]["message"] != "")'
+
+      # Transform processor to extract Pod information from events for k8sattributes matching
+      transform/extract-pod-info:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              # For v1 events (involvedObject field)
+              # Extract pod UID from involvedObject for k8sattributes processor matching
+              - set(resource.attributes["k8s.pod.uid"], body["object"]["involvedObject"]["uid"]) where body["object"]["involvedObject"]["kind"] == "Pod"
+              - set(resource.attributes["k8s.pod.name"], body["object"]["involvedObject"]["name"]) where body["object"]["involvedObject"]["kind"] == "Pod"
+              - set(resource.attributes["k8s.namespace.name"], body["object"]["involvedObject"]["namespace"]) where body["object"]["involvedObject"]["kind"] == "Pod"
+              
+              # For events.k8s.io/v1 events (regarding field)
+              - set(resource.attributes["k8s.pod.uid"], body["object"]["regarding"]["uid"]) where body["object"]["regarding"]["kind"] == "Pod"
+              - set(resource.attributes["k8s.pod.name"], body["object"]["regarding"]["name"]) where body["object"]["regarding"]["kind"] == "Pod"
+              - set(resource.attributes["k8s.namespace.name"], body["object"]["regarding"]["namespace"]) where body["object"]["regarding"]["kind"] == "Pod"
+
+      # Transform processor to set final resource attributes
+      transform/set-attributes:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(resource.attributes["log.type"], attributes["log_type"])
+              
+              # Copy enriched labels from k8sattributes to resource attributes
+              - set(resource.attributes["component.id"], attributes["component.id"]) where attributes["component.id"] != nil
+              - set(resource.attributes["workload.id"], attributes["workload.id"]) where attributes["workload.id"] != nil
+  
+              # Replace body with plain text note or message
+              - set(body, body["object"]["message"]) where body["object"]["message"] != nil and body["object"]["note"] == nil
+              - set(body, body["object"]["note"]) where body["object"]["note"] != nil
+    exporters:
+      otlp:
+        endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
+        tls:
+          insecure: true
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [k8sobjects]
+          processors: [transform/extract-pod-info, k8sattributes, attributes, transform/set-attributes]
+          exporters: [otlp, debug]
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-metrics-k8s
+  namespace: {{ .Release.Namespace }}
+spec:
+  mode: deployment
+  serviceAccount: otel-collector
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0"
+  replicas: 1
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8888"
+  resources:
+    limits:
+      cpu: {{ .Values.collectors.resources.metrics.limits.cpu | quote }}
+      memory: {{ .Values.collectors.resources.metrics.limits.memory }}
+    requests:
+      cpu: {{ .Values.collectors.resources.metrics.requests.cpu | quote }}
+      memory: {{ .Values.collectors.resources.metrics.requests.memory }}
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              job_name: kubernetes-apiservers
+              kubernetes_sd_configs:
+              - role: endpoints
+              relabel_configs:
+              - action: keep
+                regex: default;kubernetes;https
+                source_labels:
+                - __meta_kubernetes_namespace
+                - __meta_kubernetes_service_name
+                - __meta_kubernetes_endpoint_port_name
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              job_name: kubernetes-nodes
+              kubernetes_sd_configs:
+              - role: node
+              relabel_configs:
+              - action: labelmap
+                regex: __meta_kubernetes_node_label_(.+)
+              - replacement: kubernetes.default.svc:443
+                target_label: __address__
+              - regex: (.+)
+                replacement: /api/v1/nodes/$1/proxy/metrics
+                source_labels:
+                - __meta_kubernetes_node_name
+                target_label: __metrics_path__
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              job_name: kubernetes-nodes-cadvisor
+              kubernetes_sd_configs:
+              - role: node
+              relabel_configs:
+              - action: labelmap
+                regex: __meta_kubernetes_node_label_(.+)
+              - replacement: kubernetes.default.svc:443
+                target_label: __address__
+              - regex: (.+)
+                replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+                source_labels:
+                - __meta_kubernetes_node_name
+                target_label: __metrics_path__
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - honor_labels: true
+              job_name: kubernetes-service-endpoints
+              kubernetes_sd_configs:
+              - role: endpoints
+              relabel_configs:
+              - action: keep
+                regex: true
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+              - action: drop
+                regex: true
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+              - action: replace
+                regex: (https?)
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+                target_label: __scheme__
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: (.+?)(?::\d+)?;(\d+)
+                replacement: $1:$2
+                source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                replacement: __param_$1
+              - action: labelmap
+                regex: __meta_kubernetes_service_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_service_name
+                target_label: service
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_node_name
+                target_label: node
+            - honor_labels: true
+              job_name: kubernetes-service-endpoints-slow
+              kubernetes_sd_configs:
+              - role: endpoints
+              relabel_configs:
+              - action: keep
+                regex: true
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+              - action: replace
+                regex: (https?)
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+                target_label: __scheme__
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: (.+?)(?::\d+)?;(\d+)
+                replacement: $1:$2
+                source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                replacement: __param_$1
+              - action: labelmap
+                regex: __meta_kubernetes_service_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_service_name
+                target_label: service
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_node_name
+                target_label: node
+              scrape_interval: 5m
+              scrape_timeout: 30s
+            - honor_labels: true
+              job_name: prometheus-pushgateway
+              kubernetes_sd_configs:
+              - role: service
+              relabel_configs:
+              - action: keep
+                regex: pushgateway
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_probe
+            - honor_labels: true
+              job_name: kubernetes-services
+              kubernetes_sd_configs:
+              - role: service
+              metrics_path: /probe
+              params:
+                module:
+                - http_2xx
+              relabel_configs:
+              - action: keep
+                regex: true
+                source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_probe
+              - source_labels:
+                - __address__
+                target_label: __param_target
+              - replacement: blackbox
+                target_label: __address__
+              - source_labels:
+                - __param_target
+                target_label: instance
+              - action: labelmap
+                regex: __meta_kubernetes_service_label_(.+)
+              - source_labels:
+                - __meta_kubernetes_namespace
+                target_label: namespace
+              - source_labels:
+                - __meta_kubernetes_service_name
+                target_label: service
+            - honor_labels: true
+              job_name: kubernetes-pods
+              kubernetes_sd_configs:
+              - role: pod
+              relabel_configs:
+              - action: keep
+                regex: true
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+              - action: drop
+                regex: true
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+              - action: replace
+                regex: (https?)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+                target_label: __scheme__
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+                replacement: '[$2]:$1'
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+                - __meta_kubernetes_pod_ip
+                target_label: __address__
+              - action: replace
+                regex: (\d+);((([0-9]+?)(\.|$)){4})
+                replacement: $2:$1
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+                - __meta_kubernetes_pod_ip
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                replacement: __param_$1
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: drop
+                regex: Pending|Succeeded|Failed|Completed
+                source_labels:
+                - __meta_kubernetes_pod_phase
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_node_name
+                target_label: node
+            - honor_labels: true
+              job_name: kubernetes-pods-slow
+              kubernetes_sd_configs:
+              - role: pod
+              relabel_configs:
+              - action: keep
+                regex: true
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+              - action: replace
+                regex: (https?)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+                target_label: __scheme__
+              - action: replace
+                regex: (.+)
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_path
+                target_label: __metrics_path__
+              - action: replace
+                regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+                replacement: '[$2]:$1'
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+                - __meta_kubernetes_pod_ip
+                target_label: __address__
+              - action: replace
+                regex: (\d+);((([0-9]+?)(\.|$)){4})
+                replacement: $2:$1
+                source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+                - __meta_kubernetes_pod_ip
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                replacement: __param_$1
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: pod
+              - action: drop
+                regex: Pending|Succeeded|Failed|Completed
+                source_labels:
+                - __meta_kubernetes_pod_phase
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_node_name
+                target_label: node
+              scrape_interval: 5m
+              scrape_timeout: 30s
+            - job_name: ai-gateway-extproc
+              kubernetes_sd_configs:
+              - role: pod
+                namespaces:
+                  names:
+                  - envoy-gateway-system
+              relabel_configs:
+              - action: keep
+                regex: envoy
+                source_labels:
+                - __meta_kubernetes_pod_label_app_kubernetes_io_name
+              - action: replace
+                regex: (.+)
+                replacement: $1:1064
+                source_labels:
+                - __meta_kubernetes_pod_ip
+                target_label: __address__
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_namespace
+                target_label: namespace
+              - action: replace
+                source_labels:
+                - __meta_kubernetes_pod_name
+                target_label: pod
+              metrics_path: /metrics
+              scrape_interval: 30s
+    processors:
+      batch:
+        send_batch_size: 2000
+          #send_batch_size: 1000  # Reduced from 10000
+          #send_batch_max_size: 1000  # Added explicit max size
+        timeout: 10s
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      attributes:
+        actions:
+          - key: k8s_cluster_name
+            action: insert
+            value: {{ .Values.cluster.name | quote }}
+
+    exporters:
+      # Configure your actual backend exporters here
+      otlp:
+        endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
+        tls:
+          insecure: true
+      debug:
+        verbosity: detailed
+    
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [memory_limiter, batch, attributes]
+          exporters: [otlp]

--- a/sources/otel-lgtm-stack/v1.0.8/templates/collectors-metrics-rest.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/collectors-metrics-rest.yaml
@@ -1,0 +1,283 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-metrics-rest
+  namespace: {{ .Release.Namespace }}
+spec:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0
+  mode: deployment
+  podAnnotations:
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
+  replicas: 1
+  resources:
+    limits:
+      cpu: {{ .Values.collectors.resources.metrics.limits.cpu | quote }}
+      memory: {{ .Values.collectors.resources.metrics.limits.memory }}
+    requests:
+      cpu: {{ .Values.collectors.resources.metrics.requests.cpu | quote }}
+      memory: {{ .Values.collectors.resources.metrics.requests.memory }}
+  serviceAccount: otel-collector
+  config:
+    exporters:
+      debug:
+        verbosity: detailed
+      otlp:
+        endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
+        tls:
+          insecure: true
+    processors:
+      attributes:
+        actions:
+          - action: insert
+            key: k8s_cluster_name
+            value: {{ .Values.cluster.name | quote }}
+      batch:
+        send_batch_size: 2000
+        timeout: 10s
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: otel-collector
+              scrape_interval: 30s
+              static_configs:
+                - targets:
+                    - localhost:8888
+            - dns_sd_configs:
+                - names:
+                    - opencost-prometheus-opencost-exporter.monitoring
+                  port: 9003
+                  type: A
+              honor_labels: true
+              job_name: opencost
+              metrics_path: /metrics
+              scheme: http
+              scrape_interval: 1m
+              scrape_timeout: 10s
+            - job_name: gpu-operator-metrics-exporter
+              kubernetes_sd_configs:
+              - role: pod
+                namespaces:
+                  names:
+                  - kube-amd-gpu
+              metrics_path: /metrics
+              relabel_configs:
+              - action: keep
+                regex: gpu-operator-metrics-exporter.*
+                source_labels:
+                - __meta_kubernetes_pod_name
+              - source_labels:
+                - __meta_kubernetes_pod_ip
+                regex: (.+)
+                replacement: $1:5000
+                target_label: __address__
+              - source_labels:
+                - __meta_kubernetes_pod_node_name
+                target_label: hostname
+            - job_name: minio-cluster-metrics
+              metrics_path: /minio/v2/metrics/cluster
+              scheme: http
+              static_configs:
+                - targets:
+                    - filer-s3.seaweedfs-instance.svc.cluster.local
+            - job_name: minio-bucket-metrics
+              metrics_path: /minio/v2/metrics/bucket
+              scheme: http
+              static_configs:
+                - targets:
+                    - filer-s3.seaweedfs-instance.svc.cluster.local
+            - job_name: minio-resource-metrics
+              metrics_path: /minio/v2/metrics/resource
+              scheme: http
+              static_configs:
+                - targets:
+                    - filer-s3.seaweedfs-instance.svc.cluster.local
+            - job_name: argocd-controller
+              metrics_path: /metrics
+              scheme: http
+              static_configs:
+                - targets:
+                    - argocd-metrics.argocd.svc.cluster.local:8082
+            - job_name: argocd-applicationset
+              metrics_path: /metrics
+              scheme: http
+              static_configs:
+                - targets:
+                    - argocd-applicationset-controller.argocd.svc.cluster.local:8080
+            - job_name: argocd-repo-server
+              metrics_path: /metrics
+              scheme: http
+              static_configs:
+                - targets:
+                    - argocd-repo-server.argocd.svc.cluster.local:8084
+            - job_name: longhorn
+              metrics_path: /metrics
+              scheme: http
+              static_configs:
+                - targets:
+                    - longhorn-backend.longhorn.svc.cluster.local:9500
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch
+            - attributes
+          receivers:
+            - prometheus
+
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-metrics-chrony
+  namespace: {{ .Release.Namespace }}
+spec:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0
+  mode: deployment
+  podAnnotations:
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
+  replicas: 1
+  resources:
+    limits:
+      cpu: {{ .Values.collectors.resources.metrics.limits.cpu | quote }}
+      memory: {{ .Values.collectors.resources.metrics.limits.memory }}
+    requests:
+      cpu: {{ .Values.collectors.resources.metrics.requests.cpu | quote }}
+      memory: {{ .Values.collectors.resources.metrics.requests.memory }}
+  serviceAccount: otel-collector
+  config:
+    exporters:
+      debug:
+        verbosity: detailed
+      otlp:
+        endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
+        tls:
+          insecure: true
+    processors:
+      attributes:
+        actions:
+          - action: insert
+            key: k8s_cluster_name
+            value: {{ .Values.cluster.name | quote }}
+      batch:
+        send_batch_size: 2000
+        timeout: 10s
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: chrony-exporter
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_label_app]
+                  regex: chrony-exporter
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_ip]
+                  target_label: __address__
+                  regex: (.*)
+                  replacement: $1:9123
+                - source_labels: [__meta_kubernetes_pod_node_name]
+                  target_label: k8s_node_name
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch
+            - attributes
+          receivers:
+            - prometheus
+
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-metrics-airm
+  namespace: {{ .Release.Namespace }}
+spec:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0
+  mode: deployment
+  podAnnotations:
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
+  replicas: 1
+  resources:
+    limits:
+      cpu: {{ .Values.collectors.resources.metrics.limits.cpu | quote }}
+      memory: {{ .Values.collectors.resources.metrics.limits.memory }}
+    requests:
+      cpu: {{ .Values.collectors.resources.metrics.requests.cpu | quote }}
+      memory: {{ .Values.collectors.resources.metrics.requests.memory }}
+  serviceAccount: otel-collector
+  config:
+    exporters:
+      debug:
+        verbosity: detailed
+      otlp:
+        endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
+        tls:
+          insecure: true
+    processors:
+      attributes:
+        actions:
+          - action: insert
+            key: k8s_cluster_name
+            value: {{ .Values.cluster.name | quote }}
+      batch:
+        send_batch_size: 2000
+        timeout: 10s
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: airm-custom-metrics
+              scrape_interval: 30s
+              kubernetes_sd_configs:
+                - role: pod
+              metrics_path: /
+              relabel_configs:
+                - action: keep
+                  source_labels:
+                    - __meta_kubernetes_pod_label_app
+                  regex: airm-api
+                - regex: (.+)
+                  replacement: $1:9009
+                  source_labels:
+                    - __meta_kubernetes_node_address_InternalIP
+                  target_label: __address__
+                  action: replace
+                - source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: hostname
+
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch
+            - attributes
+          receivers:
+            - prometheus

--- a/sources/otel-lgtm-stack/v1.0.8/templates/collectors-rbac-instrumentation.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/collectors-rbac-instrumentation.yaml
@@ -1,0 +1,208 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  namespace: {{ .Release.Namespace }}
+---    
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - namespaces
+      - namespaces/status
+      - nodes
+      - nodes/spec
+      - nodes/stats
+      - nodes/metrics
+      - nodes/proxy
+      - persistentvolumes
+      - persistentvolumeclaims
+      - pods
+      - pods/status
+      - replicationcontrollers
+      - replicationcontrollers/status
+      - resourcequotas
+      - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["get", "list", "watch"]
+  # Added permission for non-resource URLs to access metrics endpoints
+  - nonResourceURLs: 
+      - "/metrics"
+      - "/metrics/cadvisor"
+      - "/stats/summary"
+      - "/api/v1/nodes/*/proxy/metrics"
+      - "/api/v1/nodes/*/proxy/metrics/cadvisor"
+    verbs: ["get"]
+  # Added networking.k8s.io API group for newer Kubernetes versions
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  # Added permission to access custom resource definitions if using any
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources:
+      - customresourcedefinitions
+    verbs: ["get", "list", "watch"]
+  # Added events.k8s.io API group for newer Kubernetes events
+  - apiGroups: ["events.k8s.io"]
+    resources:
+      - events
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+    - servicemonitors
+    - podmonitors
+    - probes
+    - scrapeconfigs
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulset
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+    - endpointslices
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector
+    namespace: {{ .Release.Namespace }}
+---
+# Source: openobserve-collector/templates/instrumentation-dotnet.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-dotnet
+  namespace: {{ .Release.Namespace }}
+spec:
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ###
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  dotnet:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+---
+# Source: openobserve-collector/templates/instrumentation-go.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-go
+  namespace: {{ .Release.Namespace }}
+spec:
+  go:
+    # image: ghcr.io/openobserve/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.7.0-alpha-5
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.19.0-alpha
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ##
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+---
+# Source: openobserve-collector/templates/instrumentation-java.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-java
+  namespace: {{ .Release.Namespace }}
+spec:
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ###
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  java:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+---
+# Source: openobserve-collector/templates/instrumentation-nodejs.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-nodejs
+  namespace: {{ .Release.Namespace }}
+spec:
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ###
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+---
+# Source: openobserve-collector/templates/instrumentation-python.yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: lgtm-python
+  namespace: {{ .Release.Namespace }}
+spec:
+  exporter:
+    endpoint: http://lgtm.lgtm-stack.svc.cluster.local:4318 ###
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  python:
+    env:
+      - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+        value: http/protobuf
+      - name: OTEL_LOGS_EXPORTER
+        value: otlp_proto_http
+      - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+        value: "false" # set to true to enable auto instrumentation for logs

--- a/sources/otel-lgtm-stack/v1.0.8/templates/config-overrides.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/config-overrides.yaml
@@ -1,0 +1,25 @@
+# ConfigMaps that override the LGTM image's embedded config files.
+# Each is mounted via subPath over /otel-lgtm/<file> in the lgtm container.
+# Guarded so an explicitly-blanked value renders nothing (falls back to the
+# image's built-in file).
+{{- if .Values.lgtm.configOverrides.lokiConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lgtm-loki-config
+  namespace: {{ .Release.Namespace }}
+data:
+  loki-config.yaml: |-
+{{ .Values.lgtm.configOverrides.lokiConfig | indent 4 }}
+{{- end }}
+{{- if .Values.lgtm.configOverrides.otelcolConfig }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lgtm-otelcol-config
+  namespace: {{ .Release.Namespace }}
+data:
+  otelcol-config.yaml: |-
+{{ .Values.lgtm.configOverrides.otelcolConfig | indent 4 }}
+{{- end }}

--- a/sources/otel-lgtm-stack/v1.0.8/templates/dashboards-cluster-health-overview.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/dashboards-cluster-health-overview.yaml
@@ -1,0 +1,767 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lgtm-cluster-health-overview
+  namespace: {{ .Release.Namespace }}
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "common"
+data:
+  cluster-health-overview.json: |-
+      {
+        "__inputs": [
+          {
+            "name": "DS_PROMETHEUS",
+            "label": "Prometheus",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
+          },
+          {
+            "name": "DS_LOKI",
+            "label": "Loki",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "loki",
+            "pluginName": "Loki"
+          }
+        ],
+        "__requires": [
+          {
+            "type": "grafana",
+            "id": "grafana",
+            "name": "Grafana",
+            "version": "10.0.0"
+          },
+          {
+            "type": "datasource",
+            "id": "prometheus",
+            "name": "Prometheus",
+            "version": "1.0.0"
+          },
+          {
+            "type": "datasource",
+            "id": "loki",
+            "name": "Loki",
+            "version": "1.0.0"
+          },
+          {
+            "type": "panel",
+            "id": "gauge",
+            "name": "Gauge",
+            "version": ""
+          },
+          {
+            "type": "panel",
+            "id": "logs",
+            "name": "Logs",
+            "version": ""
+          }
+        ],
+        "annotations": {
+          "list": []
+        },
+        "description": "Disk space usage for root and /mnt/disk* partitions",
+        "editable": true,
+        "fiscalYearStartMonth": 0,
+        "graphTooltip": 1,
+        "id": null,
+        "links": [],
+        "panels": [
+          {
+            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "fieldConfig": {
+              "defaults": {
+                "color": { "mode": "thresholds" },
+                "custom": {
+                  "align": "left",
+                  "cellOptions": { "type": "auto" },
+                  "inspect": false
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": null }]
+                },
+                "decimals": 1
+              },
+              "overrides": [
+                {
+                  "matcher": { "id": "byName", "options": "Used (GB)" },
+                  "properties": [
+                    { "id": "unit", "value": "decgbytes" }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "Capacity (GB)" },
+                  "properties": [
+                    { "id": "unit", "value": "decgbytes" }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "Used %" },
+                  "properties": [
+                    { "id": "unit", "value": "percent" },
+                    { "id": "thresholds", "value": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 }] } },
+                    { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } }
+                  ]
+                }
+              ]
+            },
+            "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+            "id": 2,
+            "options": {
+              "cellHeight": "sm",
+              "footer": { "show": false },
+              "showHeader": true,
+              "sortBy": [{ "desc": true, "displayName": "Used (GB)" }]
+            },
+            "title": "Disk Space Details",
+            "type": "table",
+            "transformations": [
+              { "id": "merge", "options": {} },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": { "Time": true, "__name__": true, "job": true, "instance": true },
+                  "renameByName": {
+                    "device": "Device",
+                    "mountpoint": "Mount Point",
+                    "nodename": "Hostname",
+                    "Value #A": "Capacity (GB)",
+                    "Value #B": "Used (GB)",
+                    "Value #C": "Used %",
+                    "Value #total": "Capacity (GB)",
+                    "Value #used_gb": "Used (GB)",
+                    "Value #used_pct": "Used %"
+                  },
+                  "indexByName": {
+                    "nodename": 0,
+                    "device": 1,
+                    "mountpoint": 2,
+                    "Value #used_gb": 3,
+                    "Value #total": 4,
+                    "Value #used_pct": 5,
+                    "Value #B": 3,
+                    "Value #A": 4,
+                    "Value #C": 5
+                  }
+                }
+              }
+            ],
+            "targets": [
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "sum by (nodename, device, mountpoint) ((node_filesystem_size_bytes{instance=~\"$instance\", mountpoint=~\"^/$|^/mnt(/.*)?$|^/var/lib/rancher(/.*)?$\", fstype!~\"tmpfs|overlay|squashfs|fuse.lxcfs\"} / 1024 / 1024 / 1024) * on(instance) group_left(nodename) node_uname_info{instance=~\"$instance\"})",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "A"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "sum by (nodename, device, mountpoint) ((((node_filesystem_size_bytes{instance=~\"$instance\", mountpoint=~\"^/$|^/mnt(/.*)?$|^/var/lib/rancher(/.*)?$\", fstype!~\"tmpfs|overlay|squashfs|fuse.lxcfs\"} - node_filesystem_avail_bytes{instance=~\"$instance\", mountpoint=~\"^/$|^/mnt(/.*)?$|^/var/lib/rancher(/.*)?$\", fstype!~\"tmpfs|overlay|squashfs|fuse.lxcfs\"}) / 1024 / 1024 / 1024) * on(instance) group_left(nodename) node_uname_info{instance=~\"$instance\"}))",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "B"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "sum by (nodename, device, mountpoint) (((100 - (node_filesystem_avail_bytes{instance=~\"$instance\", mountpoint=~\"^/$|^/mnt(/.*)?$|^/var/lib/rancher(/.*)?$\", fstype!~\"tmpfs|overlay|squashfs|fuse.lxcfs\"} / node_filesystem_size_bytes{instance=~\"$instance\", mountpoint=~\"^/$|^/mnt(/.*)?$|^/var/lib/rancher(/.*)?$\", fstype!~\"tmpfs|overlay|squashfs|fuse.lxcfs\"} * 100)) * on(instance) group_left(nodename) node_uname_info{instance=~\"$instance\"}))",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "C"
+              }
+            ]
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "fieldConfig": {
+              "defaults": {
+                "color": { "mode": "thresholds" },
+                "custom": {
+                  "align": "left",
+                  "cellOptions": { "type": "auto" },
+                  "inspect": false
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": null }]
+                },
+                "decimals": 1
+              },
+              "overrides": [
+                {
+                  "matcher": { "id": "byName", "options": "Role" },
+                  "properties": [
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "options": {
+                            "0": { "text": "Agent" },
+                            "1": { "text": "Server" }
+                          },
+                          "type": "value"
+                        },
+                        {
+                          "options": {
+                            "match": "null",
+                            "result": { "text": "Agent" }
+                          },
+                          "type": "special"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "Node Status" },
+                  "properties": [
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "options": {
+                            "0": { "text": "NotReady" },
+                            "1": { "text": "Ready" }
+                          },
+                          "type": "value"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          { "color": "red", "value": null },
+                          { "color": "green", "value": 1 }
+                        ]
+                      }
+                    },
+                    { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "CPU Usage %" },
+                  "properties": [
+                    { "id": "unit", "value": "percent" },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          { "color": "green", "value": null },
+                          { "color": "yellow", "value": 70 },
+                          { "color": "red", "value": 85 }
+                        ]
+                      }
+                    },
+                    { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "Memory Usage %" },
+                  "properties": [
+                    { "id": "unit", "value": "percent" },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          { "color": "green", "value": null },
+                          { "color": "yellow", "value": 70 },
+                          { "color": "red", "value": 85 }
+                        ]
+                      }
+                    },
+                    { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "Since Reboot" },
+                  "properties": [
+                    { "id": "unit", "value": "s" }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "GPU Detected" },
+                  "properties": [
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "options": {
+                            "0": { "text": "No" },
+                            "1": { "text": "Yes" }
+                          },
+                          "type": "value"
+                        },
+                        {
+                          "options": {
+                            "match": "null",
+                            "result": { "text": "No" }
+                          },
+                          "type": "special"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          { "color": "red", "value": null },
+                          { "color": "green", "value": 1 }
+                        ]
+                      }
+                    },
+                    { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } }
+                  ]
+                }
+              ]
+            },
+            "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+            "id": 3,
+            "options": {
+              "cellHeight": "sm",
+              "footer": { "show": false },
+              "showHeader": true,
+              "sortBy": [{ "desc": true, "displayName": "Memory Usage %" }]
+            },
+            "title": "Node Health Details",
+            "type": "table",
+            "transformations": [
+              { "id": "merge", "options": {} },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true, "node": true },
+                  "renameByName": {
+                    "hostname": "Hostname",
+                    "Value #role": "Role",
+                    "Value #status": "Node Status",
+                    "Value #cpu": "CPU Usage %",
+                    "Value #mem": "Memory Usage %",
+                    "Value #reboot": "Since Reboot",
+                    "Value #gpu": "GPU Detected"
+                  },
+                  "indexByName": {
+                    "hostname": 0,
+                    "Value #role": 1,
+                    "Value #status": 2,
+                    "Value #cpu": 3,
+                    "Value #mem": 4,
+                    "Value #reboot": 5,
+                    "Value #gpu": 6
+                  }
+                }
+              }
+            ],
+            "targets": [
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "max by (hostname) (label_replace(kube_node_role{role=~\"control-plane|master\"}, \"hostname\", \"$1\", \"node\", \"(.*)\"))",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "role"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "max by (hostname) (label_replace(kube_node_status_condition{condition=\"Ready\",status=\"true\"}, \"hostname\", \"$1\", \"node\", \"(.*)\"))",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "status"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$instance\"}[5m]) * on(instance) group_left(hostname) label_replace(node_uname_info{instance=~\"$instance\"}, \"hostname\", \"$1\", \"nodename\", \"(.*)\")) * 100)",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "cpu"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "100 * (1 - avg by (hostname) ((node_memory_MemAvailable_bytes{instance=~\"$instance\"} * on(instance) group_left(hostname) label_replace(node_uname_info{instance=~\"$instance\"}, \"hostname\", \"$1\", \"nodename\", \"(.*)\")) / (node_memory_MemTotal_bytes{instance=~\"$instance\"} * on(instance) group_left(hostname) label_replace(node_uname_info{instance=~\"$instance\"}, \"hostname\", \"$1\", \"nodename\", \"(.*)\"))))",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "mem"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "avg by (hostname) ((time() - node_boot_time_seconds{instance=~\"$instance\"}) * on(instance) group_left(hostname) label_replace(node_uname_info{instance=~\"$instance\"}, \"hostname\", \"$1\", \"nodename\", \"(.*)\"))",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "reboot"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "max by (hostname) ((label_replace((kube_node_status_capacity{resource=~\".*gpu.*\"} > 0), \"hostname\", \"$1\", \"node\", \"(.*)\")) or on(hostname) (label_replace(node_uname_info{instance=~\"$instance\"}, \"hostname\", \"$1\", \"nodename\", \"(.*)\") * 0))",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "gpu"
+              }
+            ]
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "description": "Per-node CPU usage (1 - idle). Same expression as the **Node Health Details** table column, plotted over time.",
+            "fieldConfig": {
+              "defaults": {
+                "color": { "mode": "palette-classic" },
+                "custom": {
+                  "axisPlacement": "auto",
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": { "type": "linear" },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": { "group": "A", "mode": "none" },
+                  "thresholdsStyle": { "mode": "off" }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": null }]
+                },
+                "unit": "percent",
+                "min": 0,
+                "max": 100
+              },
+              "overrides": []
+            },
+            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+            "id": 7,
+            "options": {
+              "legend": {
+                "calcs": ["mean", "max", "lastNotNull"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": { "mode": "multi", "sort": "desc" }
+            },
+            "targets": [
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$instance\"}[5m]) * on(instance) group_left(hostname) label_replace(node_uname_info{instance=~\"$instance\"}, \"hostname\", \"$1\", \"nodename\", \"(.*)\")) * 100)",
+              "legendFormat": "{{ "{{" }}hostname{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU Usage % by Node",
+            "type": "timeseries"
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "description": "Per-node memory usage (1 - MemAvailable / MemTotal). Same expression as the **Node Health Details** table column, plotted over time.",
+            "fieldConfig": {
+              "defaults": {
+                "color": { "mode": "palette-classic" },
+                "custom": {
+                  "axisPlacement": "auto",
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": { "type": "linear" },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": { "group": "A", "mode": "none" },
+                  "thresholdsStyle": { "mode": "off" }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": null }]
+                },
+                "unit": "percent",
+                "min": 0,
+                "max": 100
+              },
+              "overrides": []
+            },
+            "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+            "id": 8,
+            "options": {
+              "legend": {
+                "calcs": ["mean", "max", "lastNotNull"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": { "mode": "multi", "sort": "desc" }
+            },
+            "targets": [
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "100 * (1 - avg by (hostname) ((node_memory_MemAvailable_bytes{instance=~\"$instance\"} * on(instance) group_left(hostname) label_replace(node_uname_info{instance=~\"$instance\"}, \"hostname\", \"$1\", \"nodename\", \"(.*)\")) / (node_memory_MemTotal_bytes{instance=~\"$instance\"} * on(instance) group_left(hostname) label_replace(node_uname_info{instance=~\"$instance\"}, \"hostname\", \"$1\", \"nodename\", \"(.*)\"))))",
+              "legendFormat": "{{ "{{" }}hostname{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Usage % by Node",
+            "type": "timeseries"
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "description": "Cluster-wide GPU utilization across all GPUs reporting `gpu_gfx_activity`. Three lines: minimum, average and maximum across the fleet. Stays empty if no GPU metrics are present.",
+            "fieldConfig": {
+              "defaults": {
+                "color": { "mode": "palette-classic" },
+                "custom": {
+                  "axisPlacement": "auto",
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": { "type": "linear" },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": { "group": "A", "mode": "none" },
+                  "thresholdsStyle": { "mode": "off" }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": null }]
+                },
+                "unit": "percent",
+                "min": 0,
+                "max": 100
+              },
+              "overrides": [
+                {
+                  "matcher": { "id": "byName", "options": "Avg" },
+                  "properties": [
+                    { "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } },
+                    { "id": "custom.lineWidth", "value": 3 }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "Max" },
+                  "properties": [
+                    { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }
+                  ]
+                },
+                {
+                  "matcher": { "id": "byName", "options": "Min" },
+                  "properties": [
+                    { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }
+                  ]
+                }
+              ]
+            },
+            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+            "id": 9,
+            "options": {
+              "legend": {
+                "calcs": ["mean", "max", "lastNotNull"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": { "mode": "multi", "sort": "desc" }
+            },
+            "targets": [
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "avg(gpu_gfx_activity)",
+                "legendFormat": "Avg",
+                "refId": "A"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "max(gpu_gfx_activity)",
+                "legendFormat": "Max",
+                "refId": "B"
+              },
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "min(gpu_gfx_activity)",
+                "legendFormat": "Min",
+                "refId": "C"
+              }
+            ],
+            "timeFrom": "24h",
+            "title": "GPU Utilization % (Cluster Aggregate)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "description": "Per-GPU activity from the AMD SMI exporter (`gpu_gfx_activity`). Each line is one GPU keyed by node and GPU UUID. Stays empty if no GPU metrics are present.",
+            "fieldConfig": {
+              "defaults": {
+                "color": { "mode": "palette-classic" },
+                "custom": {
+                  "axisPlacement": "auto",
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": { "type": "linear" },
+                  "showPoints": "never",
+                  "spanNulls": false,
+                  "stacking": { "group": "A", "mode": "none" },
+                  "thresholdsStyle": { "mode": "off" }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": null }]
+                },
+                "unit": "percent",
+                "min": 0,
+                "max": 100
+              },
+              "overrides": []
+            },
+            "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+            "id": 10,
+            "options": {
+              "legend": {
+                "calcs": ["mean", "max", "lastNotNull"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": { "mode": "multi", "sort": "desc" }
+            },
+            "targets": [
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "gpu_gfx_activity",
+              "legendFormat": "{{ "{{" }}node{{ "}}" }} / {{ "{{" }}gpu_uuid{{ "}}" }}",
+              "refId": "A"
+              }
+            ],
+            "title": "GPU Utilization % by GPU",
+            "type": "timeseries"
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "prometheus" },
+            "fieldConfig": {
+              "defaults": {
+                "color": { "mode": "thresholds" },
+                "custom": {
+                  "align": "left",
+                  "cellOptions": { "type": "auto" },
+                  "inspect": false
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": null }]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": { "id": "byName", "options": "Age" },
+                  "properties": [
+                    { "id": "unit", "value": "s" }
+                  ]
+                }
+              ]
+            },
+            "gridPos": { "h": 10, "w": 24, "x": 0, "y": 32 },
+            "id": 4,
+            "options": {
+              "cellHeight": "sm",
+              "footer": { "show": false },
+              "showHeader": true,
+              "sortBy": [{ "desc": true, "displayName": "Age" }]
+            },
+            "title": "Crashing/Error/Not-Running Pods",
+            "type": "table",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": { "Time": true, "__name__": true, "condition": true, "instance": true, "job": true, "uid": true },
+                  "renameByName": {
+                    "namespace": "Namespace",
+                    "pod": "Pod",
+                    "phase": "Pod Status",
+                    "Value": "Age"
+                  },
+                  "indexByName": {
+                    "namespace": 0,
+                    "pod": 1,
+                    "phase": 2,
+                    "Value": 3
+                  }
+                }
+              }
+            ],
+            "targets": [
+              {
+                "datasource": { "type": "prometheus", "uid": "prometheus" },
+                "expr": "max by (namespace, pod, phase) (((time() - kube_pod_created) * on(namespace, pod) group_left(phase) max by (namespace, pod, phase) (kube_pod_status_phase{phase=~\"Pending|Running|Failed|Unknown\"} == 1)) * on(namespace, pod) group_left() (max by (namespace, pod) (kube_pod_container_status_waiting_reason{reason=~\"CrashLoopBackOff|ImagePullBackOff|ErrImagePull|CreateContainerConfigError|CreateContainerError\"} == 1) or max by (namespace, pod) (kube_pod_container_status_terminated_reason{reason=~\"Error|OOMKilled|ContainerCannotRun\"} == 1) or max by (namespace, pod) (kube_pod_status_phase{phase=~\"Pending|Failed|Unknown\"} == 1) or max by (namespace, pod) (kube_pod_status_ready{condition=\"true\"} == 0)))",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ]
+          }
+        ],
+        "refresh": "1m",
+        "schemaVersion": 38,
+        "tags": ["disk", "storage", "node-exporter"],
+        "templating": {
+          "list": [
+            {
+              "current": {},
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "definition": "label_values(node_filesystem_size_bytes, instance)",
+              "hide": 0,
+              "includeAll": true,
+              "multi": true,
+              "name": "instance",
+              "options": [],
+              "query": {
+                "query": "label_values(node_filesystem_size_bytes, instance)",
+                "refId": "StandardVariableQuery"
+              },
+              "refresh": 2,
+              "regex": "",
+              "sort": 1,
+              "label": "Instance",
+              "type": "query"
+            }
+          ]
+        },
+        "time": { "from": "now-5m", "to": "now" },
+        "timepicker": {},
+        "timezone": "browser",
+        "title": "Cluster Health Overview",
+        "uid": "cluster-health-overview",
+        "version": 1
+      }

--- a/sources/otel-lgtm-stack/v1.0.8/templates/dashboards-default.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/dashboards-default.yaml
@@ -1,0 +1,7073 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lgtm-k8s-nodes-overview
+  namespace: {{ .Release.Namespace }}
+  labels:
+     grafana_dashboard: "1"
+  annotations:
+     grafana_folder: "common"
+data:
+  k8s-nodes-overview.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "$$hashKey": "object:247",
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "【 resource overview 】2021.10.10 detail ，kubernetes Node information details ！ outflow K8S Node resource overview 、 Network bandwidth per second 、Pod Resource details K8S Network overview ， Optimizing important metrics display 。https://github.com/starsliao/Prometheus",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "gnetId": 15661,
+      "graphTooltip": 0,
+      "id": 1,
+      "links": [
+        {
+          "icon": "bolt",
+          "tags": [],
+          "targetBlank": true,
+          "title": "Update",
+          "tooltip": " Update current dashboard ",
+          "type": "link",
+          "url": "https://grafana.com/dashboards/13105"
+        },
+        {
+          "$$hashKey": "object:831",
+          "icon": "question",
+          "tags": [
+            "node_exporter"
+          ],
+          "targetBlank": true,
+          "title": "GitHub",
+          "tooltip": " Overall memory usage  ",
+          "type": "link",
+          "url": "https://github.com/starsliao/Prometheus"
+        },
+        {
+          "$$hashKey": "object:1091",
+          "asDropdown": true,
+          "icon": "external link",
+          "tags": [],
+          "targetBlank": true,
+          "type": "dashboards"
+        }
+      ],
+      "panels": [
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 54,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": " Node Storage Information ： Number of cores used :【$Node】",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "decimals": 1,
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": null
+                  },
+                  {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "rgba(245, 54, 54, 0.9)",
+                    "value": 0.99
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 1
+          },
+          "id": 44,
+          "options": {
+            "displayMode": "basic",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Memory Limit Rate ",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Total memory usage ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": " Total Memory Demand ",
+              "refId": "B",
+              "step": 10
+            }
+          ],
+          "title": " Overall core usage ",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "decimals": 1,
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": null
+                  },
+                  {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "rgba(245, 54, 54, 0.9)",
+                    "value": 0.99
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 1
+          },
+          "id": 45,
+          "options": {
+            "displayMode": "basic",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m])) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "CPU Request Rate ",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "CPU total memory ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "CPU Nodes ",
+              "refId": "B"
+            }
+          ],
+          "title": " container CPU proportion ",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": " Memory Request Rate ， container POD core ， container POD disk ",
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "max": 1000,
+              "min": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1000
+                  },
+                  {
+                    "color": "red",
+                    "value": 2000
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 8,
+            "y": 1
+          },
+          "id": 74,
+          "options": {
+            "displayMode": "basic",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "count(kube_node_info{origin_prometheus=~\"$origin_prometheus\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Total Cores ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",created_by_kind!~\"<none>|Job\",node=~\"^$Node$\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Pod core ",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"pods\", unit=\"integer\",node=~\"^$Node$\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": " disk Pod",
+              "refId": "C"
+            }
+          ],
+          "title": " microservice Pod",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "center",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " use "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 8
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Pod"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 21
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SVC"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 7
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " usage "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 4
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " memory "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 16
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " request "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 33
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 11,
+            "y": 1
+          },
+          "id": 51,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": " use "
+              }
+            ]
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}) by (namespace)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "count(kube_service_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "count(count(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\"}) by(container,namespace))by(namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "count(kube_configmap_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "configmap",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "count(kube_secret_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "secret",
+              "refId": "E"
+            }
+          ],
+          "title": " average memory ",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "namespace"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time 1": true,
+                  "Time 2": true,
+                  "Time 3": true,
+                  "Time 4": true,
+                  "Time 5": true
+                },
+                "indexByName": {
+                  "Time 1": 2,
+                  "Time 2": 4,
+                  "Time 3": 6,
+                  "Value #A": 3,
+                  "Value #C": 5,
+                  "Value #D": 1,
+                  "namespace": 0
+                },
+                "renameByName": {
+                  "Time 1": "",
+                  "Time 2": "",
+                  "Value #A": "Pod",
+                  "Value #B": " memory ",
+                  "Value #C": "SVC",
+                  "Value #D": " usage ",
+                  "Value #E": " request ",
+                  "namespace": " use "
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binbps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "id": 32,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false,
+              "width": 200
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "7.5.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (rate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m]))*8",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": " inflow ",
+              "metric": "network",
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (rate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m]))*8",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": " status ",
+              "metric": "network",
+              "refId": "B",
+              "step": 10
+            }
+          ],
+          "title": "$NameSpace： selected nodes （ Associating nodes and namespaces ）",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "decimals": 1,
+              "mappings": [],
+              "max": 1000000000000,
+              "min": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 800000000000
+                  },
+                  {
+                    "color": "red",
+                    "value": 1000000000000
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 5
+          },
+          "id": 71,
+          "options": {
+            "displayMode": "basic",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Requests ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Nodes ",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " total disk ",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " limit rate ",
+              "refId": "B"
+            }
+          ],
+          "title": " Resource comprehensive display ",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "decimals": 1,
+              "mappings": [],
+              "max": 500,
+              "min": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 500
+                  },
+                  {
+                    "color": "red",
+                    "value": 1000
+                  }
+                ]
+              },
+              "unit": "locale"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 5
+          },
+          "id": 72,
+          "options": {
+            "displayMode": "basic",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " usage ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",id=\"/\",node=~\"^$Node$\"}[2m]))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Nodes ",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " total disk ",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " limit rate ",
+              "refId": "B"
+            }
+          ],
+          "title": " container CPU node ",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "decimals": 2,
+              "mappings": [],
+              "max": 8000000000000,
+              "min": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 5000000000000
+                  },
+                  {
+                    "color": "red",
+                    "value": 10000000000000
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " Request Rate "
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "percentage",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "red",
+                          "value": 90
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 8,
+            "y": 5
+          },
+          "id": 73,
+          "options": {
+            "displayMode": "basic",
+            "maxVizHeight": 300,
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "auto",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "text": {},
+            "valueMode": "color"
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) / sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Request Rate ",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Nodes ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " name ",
+              "refId": "B"
+            }
+          ],
+          "title": " Node memory ratio ",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "center",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Pod"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 51
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " include "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 51
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU limit ( number )"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 63
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU total "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 54
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU total "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 58
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " memory request "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 78
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " Total Memory "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 76
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " Network bandwidth "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 83
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " English version "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " container name "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 84
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " config %"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 92
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " Memory Usage %"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 63
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " Network bandwidth %"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 59
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU limit %"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 81
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU max %"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 77
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU total %"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 59
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " English version %"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": ".*%"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "percentage",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "red",
+                          "value": 90
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "gradient",
+                      "type": "color-background"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "( memory request | Total Memory | Memory Usage | Network bandwidth | English version | container name )"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " container "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 96
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " memory request %"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 67
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": " Memory Usage "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 75
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU max "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 58
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "(CPU total | Total Memory | container name |Pod disk )"
+                },
+                "properties": [
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "gradient",
+                      "type": "color-background"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "blue",
+                          "value": null
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Pod disk "
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 54
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "CPU limit \\( number \\)$| memory request $| English version $"
+                },
+                "properties": [
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 52,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": " English version %"
+              }
+            ]
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",created_by_kind!~\"<none>|Job\",node=~\"^$Node$\"}) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "pod core ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "kube_node_status_condition{origin_prometheus=~\"$origin_prometheus\",status=\"true\",node=~\"^$Node$\"}  == 1",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": " include ",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m])) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "I"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"} - 0",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "F"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "J"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"}) by (node) - 0",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "G"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "H"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "K"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "L"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": " memory request %",
+              "refId": "M"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Memory Usage %",
+              "refId": "N"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Network bandwidth %",
+              "refId": "O"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m]))by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "CPU limit %",
+              "refId": "P"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "CPU max %",
+              "refId": "Q"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": " Network bandwidth %",
+              "refId": "R"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})by (node) / sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": " English version %",
+              "refId": "S"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"pods\", unit=\"integer\",node=~\"^$Node$\"})by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Pod disk ",
+              "refId": "T"
+            }
+          ],
+          "title": "$Node： Node memory details ",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Time 1": true,
+                  "Time 10": true,
+                  "Time 11": true,
+                  "Time 12": true,
+                  "Time 13": true,
+                  "Time 14": true,
+                  "Time 15": true,
+                  "Time 16": true,
+                  "Time 17": true,
+                  "Time 18": true,
+                  "Time 19": true,
+                  "Time 2": true,
+                  "Time 20": true,
+                  "Time 3": true,
+                  "Time 4": true,
+                  "Time 5": true,
+                  "Time 6": true,
+                  "Time 7": true,
+                  "Time 8": true,
+                  "Time 9": true,
+                  "Value #B": true,
+                  "Value #E": false,
+                  "Value #F": false,
+                  "__name__": true,
+                  "app_kubernetes_io_name": true,
+                  "app_kubernetes_io_name 1": true,
+                  "app_kubernetes_io_name 2": true,
+                  "app_kubernetes_io_name 3": true,
+                  "app_kubernetes_io_version": true,
+                  "app_kubernetes_io_version 1": true,
+                  "app_kubernetes_io_version 2": true,
+                  "app_kubernetes_io_version 3": true,
+                  "condition": false,
+                  "instance": true,
+                  "instance 1": true,
+                  "instance 2": true,
+                  "instance 3": true,
+                  "job": true,
+                  "job 1": true,
+                  "job 2": true,
+                  "job 3": true,
+                  "k8s_namespace": true,
+                  "k8s_namespace 1": true,
+                  "k8s_namespace 2": true,
+                  "k8s_namespace 3": true,
+                  "k8s_sname": true,
+                  "k8s_sname 1": true,
+                  "k8s_sname 2": true,
+                  "k8s_sname 3": true,
+                  "origin_prometheus": true,
+                  "origin_prometheus 1": true,
+                  "origin_prometheus 2": true,
+                  "origin_prometheus 3": true,
+                  "resource": true,
+                  "status": true,
+                  "unit": true
+                },
+                "indexByName": {
+                  "Time": 26,
+                  "Value #A": 3,
+                  "Value #B": 6,
+                  "Value #C": 7,
+                  "Value #D": 14,
+                  "Value #E": 10,
+                  "Value #F": 12,
+                  "Value #G": 17,
+                  "Value #H": 19,
+                  "Value #I": 8,
+                  "Value #J": 15,
+                  "Value #K": 22,
+                  "Value #L": 21,
+                  "Value #M": 16,
+                  "Value #N": 18,
+                  "Value #O": 20,
+                  "Value #P": 9,
+                  "Value #Q": 11,
+                  "Value #R": 13,
+                  "Value #S": 23,
+                  "Value #T": 2,
+                  "__name__": 4,
+                  "app_kubernetes_io_name": 27,
+                  "app_kubernetes_io_version": 28,
+                  "condition": 1,
+                  "instance": 29,
+                  "job": 30,
+                  "k8s_namespace": 31,
+                  "k8s_sname": 32,
+                  "node": 0,
+                  "origin_prometheus": 33,
+                  "resource": 24,
+                  "status": 5,
+                  "unit": 25
+                },
+                "renameByName": {
+                  "Value #A": "Pod",
+                  "Value #C": "CPU total ",
+                  "Value #D": " Total Memory ",
+                  "Value #E": "CPU max ",
+                  "Value #F": "CPU total ",
+                  "Value #G": " Memory Usage ",
+                  "Value #H": " Network bandwidth ",
+                  "Value #I": "CPU limit ( number )",
+                  "Value #J": " memory request ",
+                  "Value #K": " English version ",
+                  "Value #L": " container name ",
+                  "Value #M": " memory request %",
+                  "Value #N": " Memory Usage %",
+                  "Value #O": " Network bandwidth %",
+                  "Value #P": "CPU limit %",
+                  "Value #Q": "CPU max %",
+                  "Value #R": "CPU total %",
+                  "Value #S": " English version %",
+                  "Value #T": "Pod disk ",
+                  "condition": " include ",
+                  "node": " container "
+                }
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {}
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/ usage .*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#C4162A",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 17
+          },
+          "id": 75,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "7.5.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m]))by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)*100",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{ "{{" }}node{{ "}}" }}",
+              "refId": "I"
+            }
+          ],
+          "title": "$Node： container CPU receive ",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 17
+          },
+          "id": 76,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "7.5.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)*100",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{ "{{" }}node{{ "}}" }}",
+              "refId": "I"
+            }
+          ],
+          "title": "$Node： Node Memory Information ",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binbps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 17
+          },
+          "id": 78,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "7.5.11",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}[2m]))by (node) *8",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": " update :{{ "{{" }}node{{ "}}" }}",
+              "metric": "network",
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum (irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}[2m]))by (node) *8",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": " restart :{{ "{{" }}node{{ "}}" }}",
+              "metric": "network",
+              "refId": "B",
+              "step": 10
+            }
+          ],
+          "title": "$Node： Overall resource overview ",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "id": 61,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": false
+                  },
+                  "displayName": "",
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "orange",
+                        "value": 70
+                      },
+                      {
+                        "color": "red",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*%.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": " Requests .*"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Number of cluster nodes "
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "orange",
+                              "value": 10737418240
+                            },
+                            {
+                              "color": "red",
+                              "value": 16106127360
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".* total "
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " total CPU total "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 84
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Total Disk Usage "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 77
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Selected microservices (RSS) "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 119
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Total memory limit "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 82
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " limit amount "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 69
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "orange"
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Resource Details %(RSS)"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 112
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " password CPU%( overall 100%)"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Node Network Overview "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " total CPU selected "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 82
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Resource Details %(WSS)"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Selected microservices (WSS)"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 120
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " average memory "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 79
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": " Node Network Overview $| Selected microservices \\(WSS\\)$| Selected microservices \\(RSS\\) $"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " container number "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 149
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 2
+              },
+              "id": 57,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": " container number "
+                  }
+                ]
+              },
+              "pluginVersion": "7.5.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}/100000) by (container)) * 100",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": " Node Network Overview ",
+                  "refId": "L"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                  "format": "table",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "I"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": " Resource Details %(RSS)",
+                  "refId": "H"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": " Selected microservices (RSS) ",
+                  "refId": "K"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "F"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum(container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                  "format": "table",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "J"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "count(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by(container,namespace) - 0",
+                  "format": "table",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "G"
+                }
+              ],
+              "title": " usage ( container number ) namespace ",
+              "transformations": [
+                {
+                  "id": "merge",
+                  "options": {}
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "Time 1": true,
+                      "Time 10": true,
+                      "Time 11": true,
+                      "Time 12": true,
+                      "Time 2": true,
+                      "Time 3": true,
+                      "Time 4": true,
+                      "Time 5": true,
+                      "Time 6": true,
+                      "Time 7": true,
+                      "Time 8": true,
+                      "Time 9": true
+                    },
+                    "indexByName": {
+                      "Time 1": 2,
+                      "Time 10": 20,
+                      "Time 11": 22,
+                      "Time 12": 24,
+                      "Time 2": 4,
+                      "Time 3": 6,
+                      "Time 4": 8,
+                      "Time 5": 10,
+                      "Time 6": 12,
+                      "Time 7": 14,
+                      "Time 8": 16,
+                      "Time 9": 18,
+                      "Value #A": 3,
+                      "Value #B": 7,
+                      "Value #C": 9,
+                      "Value #D": 13,
+                      "Value #E": 19,
+                      "Value #F": 21,
+                      "Value #G": 25,
+                      "Value #H": 15,
+                      "Value #I": 11,
+                      "Value #J": 23,
+                      "Value #K": 17,
+                      "Value #L": 5,
+                      "container": 1,
+                      "namespace": 0
+                    },
+                    "renameByName": {
+                      "Time 1": "",
+                      "Value #A": " password CPU%( overall 100%)",
+                      "Value #B": " total CPU selected ",
+                      "Value #C": " total CPU total ",
+                      "Value #D": " Selected microservices (WSS)",
+                      "Value #E": " Total memory limit ",
+                      "Value #F": " Total Disk Usage ",
+                      "Value #G": " limit amount ",
+                      "Value #H": " Resource Details %(RSS)",
+                      "Value #I": " Resource Details %(WSS)",
+                      "Value #J": " Number of cluster nodes ",
+                      "Value #K": " Selected microservices (RSS) ",
+                      "Value #L": " Node Network Overview ",
+                      "container": " container number ",
+                      "namespace": " average memory "
+                    }
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {}
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "decimals": 3,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 0,
+                "y": 10
+              },
+              "height": "",
+              "hiddenSeries": false,
+              "id": 24,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pluginVersion": "7.5.11",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum(rate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}/100000) by (container)) * 100",
+                  "hide": false,
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }} container{{ "}}" }}",
+                  "metric": "container_cpu",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeRegions": [],
+              "title": " usage ( container number ) password CPU Request Rate ( overall 100%)",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "$$hashKey": "object:5607",
+                  "format": "percent",
+                  "label": "",
+                  "logBase": 1,
+                  "show": true
+                },
+                {
+                  "$$hashKey": "object:5608",
+                  "format": "short",
+                  "logBase": 1,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 8,
+                "y": 10
+              },
+              "hiddenSeries": false,
+              "id": 59,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pluginVersion": "7.5.11",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "WSS：{{ "{{" }} container{{ "}}" }}",
+                  "metric": "container_memory_usage:sort_desc",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "RSS：{{ "{{" }} container{{ "}}" }}",
+                  "metric": "container_memory_usage:sort_desc",
+                  "refId": "B",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeRegions": [],
+              "title": " usage ( container number ) Microservice resource details ",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "$$hashKey": "object:5686",
+                  "format": "percent",
+                  "logBase": 1,
+                  "show": true
+                },
+                {
+                  "$$hashKey": "object:5687",
+                  "format": "short",
+                  "logBase": 1,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false
+              }
+            },
+            {
+              "aliasColors": {
+                " restart :wholion-lbs": "green",
+                " update :wholion-lbs": "purple"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 16,
+                "y": 10
+              },
+              "hiddenSeries": false,
+              "id": 16,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pluginVersion": "7.5.11",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(container) *8",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " update :{{ "{{" }} container{{ "}}" }}",
+                  "metric": "network",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(container) *8",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " restart :{{ "{{" }} container{{ "}}" }}",
+                  "metric": "network",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum (rate (container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
+                  "hide": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "-> {{ "{{" }} pod{{ "}}" }}",
+                  "metric": "network",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "- sum (rate (container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
+                  "hide": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "<- {{ "{{" }} pod{{ "}}" }}",
+                  "metric": "network",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeRegions": [],
+              "title": " usage ( container number ) Container memory usage ( Memory Usage )",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "$$hashKey": "object:8106",
+                  "format": "binbps",
+                  "logBase": 1,
+                  "show": true
+                },
+                {
+                  "$$hashKey": "object:8107",
+                  "format": "short",
+                  "logBase": 1,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false
+              }
+            }
+          ],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": " usage ( container number ) Memory Requirements ： Associated nodes :【$Container】",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 28
+          },
+          "id": 49,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": false
+                  },
+                  "displayName": "",
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 80
+                      },
+                      {
+                        "color": "red",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "CPU%( overall 100%)"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 140
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " average memory "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 78
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Pod core count "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 136
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " core usage "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 71
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "CPU selected "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 68
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "CPU total "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 65
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "WSS%"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 129
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "WSS"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 73
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "RSS%"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 132
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "RSS"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 68
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " resource statistics "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 69
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Network bandwidth "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 71
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " send "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 67
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 1
+                            },
+                            {
+                              "color": "red",
+                              "value": 3
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " demand "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 71
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 10737418240
+                            },
+                            {
+                              "color": "red",
+                              "value": 16106127360
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*%.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": " config .*|WSS$|RSS$"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".* total "
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " container "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 87
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": " core usage $|WSS$|RSS$"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " container number "
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 116
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 3
+              },
+              "id": 47,
+              "options": {
+                "showHeader": true,
+                "sortBy": []
+              },
+              "pluginVersion": "7.5.11",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}/100000) by (container, pod,node,namespace)) * 100",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "CPU disk usage ",
+                  "refId": "Q"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                  "format": "table",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace) * 100",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "wss%",
+                  "refId": "I"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "wss",
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace) * 100",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "rss%",
+                  "refId": "L"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "rss",
+                  "refId": "K"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "F"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                  "format": "table",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "J"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "kube_pod_container_status_restarts_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"} * on (pod) group_left(node) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}",
+                  "format": "table",
+                  "hide": false,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "H"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "cass_jvm_heap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
+                  "format": "table",
+                  "hide": true,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "M"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "cass_jvm_heap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
+                  "format": "table",
+                  "hide": true,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "N"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "cass_jvm_noheap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
+                  "format": "table",
+                  "hide": true,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "O"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "cass_jvm_noheap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
+                  "format": "table",
+                  "hide": true,
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "P"
+                }
+              ],
+              "title": "$Node：Pod Memory Limit ( Memory Usage )",
+              "transformations": [
+                {
+                  "id": "merge",
+                  "options": {}
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "Time 1": true,
+                      "Time 10": true,
+                      "Time 11": true,
+                      "Time 12": true,
+                      "Time 13": true,
+                      "Time 2": true,
+                      "Time 3": true,
+                      "Time 4": true,
+                      "Time 5": true,
+                      "Time 6": true,
+                      "Time 7": true,
+                      "Time 8": true,
+                      "Time 9": true,
+                      "Value #G": true,
+                      "__name__": true,
+                      "app_kubernetes_io_name": true,
+                      "app_kubernetes_io_name 1": true,
+                      "app_kubernetes_io_name 2": true,
+                      "app_kubernetes_io_version": true,
+                      "app_kubernetes_io_version 1": true,
+                      "app_kubernetes_io_version 2": true,
+                      "container 1": true,
+                      "container 10": true,
+                      "container 11": true,
+                      "container 12": true,
+                      "container 2": true,
+                      "container 3": true,
+                      "container 4": true,
+                      "container 5": true,
+                      "container 6": true,
+                      "container 7": true,
+                      "container 8": true,
+                      "container 9": true,
+                      "created_by_kind": true,
+                      "created_by_name": true,
+                      "host_ip": true,
+                      "instance": true,
+                      "instance 1": true,
+                      "instance 2": true,
+                      "job": true,
+                      "job 1": true,
+                      "job 2": true,
+                      "k8s_namespace": true,
+                      "k8s_namespace 1": true,
+                      "k8s_namespace 2": true,
+                      "k8s_sname": true,
+                      "k8s_sname 1": true,
+                      "k8s_sname 2": true,
+                      "namespace": false,
+                      "namespace 1": true,
+                      "namespace 10": true,
+                      "namespace 11": true,
+                      "namespace 12": false,
+                      "namespace 2": true,
+                      "namespace 3": true,
+                      "namespace 4": true,
+                      "namespace 5": true,
+                      "namespace 6": true,
+                      "namespace 7": true,
+                      "namespace 8": true,
+                      "namespace 9": true,
+                      "node 1": true,
+                      "node 10": true,
+                      "node 11": false,
+                      "node 12": true,
+                      "node 2": true,
+                      "node 3": true,
+                      "node 4": true,
+                      "node 5": true,
+                      "node 6": true,
+                      "node 7": true,
+                      "node 8": true,
+                      "node 9": true,
+                      "origin_prometheus": true,
+                      "origin_prometheus 1": true,
+                      "origin_prometheus 2": true,
+                      "phase": true,
+                      "pod_ip": true,
+                      "priority_class": true,
+                      "uid": true
+                    },
+                    "indexByName": {
+                      "Time": 23,
+                      "Value #A": 4,
+                      "Value #B": 6,
+                      "Value #C": 7,
+                      "Value #D": 9,
+                      "Value #E": 12,
+                      "Value #F": 13,
+                      "Value #H": 22,
+                      "Value #I": 8,
+                      "Value #J": 14,
+                      "Value #K": 11,
+                      "Value #L": 10,
+                      "Value #Q": 5,
+                      "app_kubernetes_io_name": 15,
+                      "app_kubernetes_io_version": 16,
+                      "container": 2,
+                      "instance": 17,
+                      "job": 18,
+                      "k8s_namespace": 19,
+                      "k8s_sname": 20,
+                      "namespace": 1,
+                      "node": 0,
+                      "origin_prometheus": 21,
+                      "pod": 3
+                    },
+                    "renameByName": {
+                      "Value #A": "CPU%( overall 100%)",
+                      "Value #B": "CPU selected ",
+                      "Value #C": "CPU total ",
+                      "Value #D": "WSS",
+                      "Value #E": " resource statistics ",
+                      "Value #F": " Network bandwidth ",
+                      "Value #H": " send ",
+                      "Value #I": "WSS%",
+                      "Value #J": " demand ",
+                      "Value #K": "RSS",
+                      "Value #L": "RSS%",
+                      "Value #Q": " core usage ",
+                      "container": " container number ",
+                      "namespace": " average memory ",
+                      "namespace 1": "",
+                      "namespace 12": " average memory ",
+                      "node": " container ",
+                      "node 1": "",
+                      "node 11": " container ",
+                      "pod": "Pod core count ",
+                      "priority_class": ""
+                    }
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        " container ",
+                        " average memory ",
+                        "Pod core count ",
+                        "CPU%( overall 100%)",
+                        " core usage ",
+                        "CPU selected ",
+                        "CPU total ",
+                        "WSS%",
+                        "WSS",
+                        "RSS%",
+                        "RSS",
+                        " resource statistics ",
+                        " Network bandwidth ",
+                        " demand ",
+                        " send ",
+                        " container number "
+                      ]
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 0,
+                "y": 11
+              },
+              "height": "",
+              "hiddenSeries": false,
+              "id": 58,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pluginVersion": "7.5.11",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}/100000) by (container, pod)) * 100",
+                  "hide": false,
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }} pod{{ "}}" }}",
+                  "metric": "container_cpu",
+                  "refId": "A",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeRegions": [],
+              "title": "Pod upper limit CPU Request Rate ( overall 100% Memory Usage )",
+              "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "$$hashKey": "object:5607",
+                  "format": "percent",
+                  "label": "",
+                  "logBase": 1,
+                  "show": true
+                },
+                {
+                  "$$hashKey": "object:5608",
+                  "format": "short",
+                  "logBase": 1,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 8,
+                "y": 11
+              },
+              "hiddenSeries": false,
+              "id": 27,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": false,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pluginVersion": "7.5.11",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod) * 100",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "WSS：{{ "{{" }} pod{{ "}}" }}",
+                  "metric": "container_memory_usage:sort_desc",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod) * 100",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "RSS：{{ "{{" }} pod{{ "}}" }}",
+                  "metric": "container_memory_usage:sort_desc",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "(cass_jvm_heap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}) / (cass_jvm_heap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}) * 100",
+                  "instant": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "Heap：{{ "{{" }} pod{{ "}}" }}",
+                  "metric": "container_memory_usage:sort_desc",
+                  "refId": "C",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeRegions": [],
+              "title": "Pod View more dashboards ( Memory Usage )",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "$$hashKey": "object:5686",
+                  "format": "percent",
+                  "logBase": 1,
+                  "max": "100",
+                  "show": true
+                },
+                {
+                  "$$hashKey": "object:5687",
+                  "format": "short",
+                  "logBase": 1,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false
+              }
+            },
+            {
+              "aliasColors": {
+                " restart :wholion-lbs": "green",
+                " update :wholion-lbs": "purple"
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "decimals": 2,
+              "editable": true,
+              "error": false,
+              "fieldConfig": {
+                "defaults": {
+                  "links": []
+                },
+                "overrides": []
+              },
+              "fill": 0,
+              "fillGradient": 0,
+              "grid": {},
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 16,
+                "y": 11
+              },
+              "hiddenSeries": false,
+              "id": 77,
+              "isNew": true,
+              "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "max": true,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pluginVersion": "7.5.11",
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(pod) *8",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " update :{{ "{{" }} pod{{ "}}" }}",
+                  "metric": "network",
+                  "refId": "A",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "exemplar": true,
+                  "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(pod) *8",
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": " restart :{{ "{{" }} pod{{ "}}" }}",
+                  "metric": "network",
+                  "refId": "B",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "sum (rate (container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
+                  "hide": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "-> {{ "{{" }} pod{{ "}}" }}",
+                  "metric": "network",
+                  "refId": "C",
+                  "step": 10
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "expr": "- sum (rate (container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
+                  "hide": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "<- {{ "{{" }} pod{{ "}}" }}",
+                  "metric": "network",
+                  "refId": "D",
+                  "step": 10
+                }
+              ],
+              "thresholds": [],
+              "timeRegions": [],
+              "title": "Pod Container memory usage ( Memory Usage )",
+              "tooltip": {
+                "msResolution": false,
+                "shared": true,
+                "sort": 2,
+                "value_type": "cumulative"
+              },
+              "type": "graph",
+              "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "$$hashKey": "object:8106",
+                  "format": "binbps",
+                  "logBase": 1,
+                  "show": true
+                },
+                {
+                  "$$hashKey": "object:8107",
+                  "format": "short",
+                  "logBase": 1,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false
+              }
+            }
+          ],
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Pod Memory Requirements ： space Pod:【$Pod】",
+          "type": "row"
+        }
+      ],
+      "refresh": "",
+      "schemaVersion": 39,
+      "tags": [
+        "StarsL.cn",
+        "Prometheus",
+        "Kubernetes"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": "",
+            "current": {
+              "isNone": true,
+              "selected": true,
+              "text": "None",
+              "value": ""
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(origin_prometheus)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "K8S",
+            "multi": false,
+            "name": "origin_prometheus",
+            "options": [],
+            "query": {
+              "query": "label_values(origin_prometheus)",
+              "refId": "Prometheus-origin_prometheus-Variable-Query"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": "",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(kube_node_info{origin_prometheus=~\"$origin_prometheus\"},node)",
+            "hide": 0,
+            "includeAll": true,
+            "label": " container ",
+            "multi": false,
+            "name": "Node",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_node_info{origin_prometheus=~\"$origin_prometheus\"},node)",
+              "refId": "Prometheus-Node-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": "",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(kube_namespace_labels{origin_prometheus=~\"$origin_prometheus\"},namespace)",
+            "hide": 0,
+            "includeAll": true,
+            "label": " average memory ",
+            "multi": false,
+            "name": "NameSpace",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_namespace_labels{origin_prometheus=~\"$origin_prometheus\"},namespace)",
+              "refId": "Prometheus-NameSpace-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\"},container)",
+            "hide": 0,
+            "includeAll": true,
+            "label": " usage ( container number )",
+            "multi": false,
+            "name": "Container",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\"},container)",
+              "refId": "Prometheus-Container-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container=~\"$Container\"},pod)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Pod",
+            "multi": false,
+            "name": "Pod",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container=~\"$Container\"},pod)",
+              "refId": "Prometheus-Pod-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "browser",
+      "title": "1     K8S for Prometheus Dashboard 20211010 EN",
+      "uid": "PwMJtdvnz",
+      "version": 1,
+      "weekStart": ""
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lgtm-k8s-volume-information
+  namespace: {{ .Release.Namespace }}
+  labels:
+     grafana_dashboard: "1"
+  annotations:
+     grafana_folder: "common"
+data:
+  k8s-volume-information.json: |-
+    {
+      "__inputs": [
+        {
+          "name": "DS_OPENSHIFT_PROMETHEUS",
+          "label": "openshift-prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__requires": [
+        {
+          "type": "panel",
+          "id": "alertlist",
+          "name": "Alert List",
+          "version": ""
+        },
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "6.5.2"
+        },
+        {
+          "type": "panel",
+          "id": "graph",
+          "name": "Graph",
+          "version": ""
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "singlestat",
+          "name": "Singlestat",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "table",
+          "name": "Table",
+          "version": ""
+        }
+      ],
+      "description": "Dashboard of Kubernetes / OpenShift volume information at cluster level as exported by Prometheus connected to Kubernetes / OpenShift.",
+      "editable": true,
+      "gnetId": 11454,
+      "graphTooltip": 1,
+      "id": null,
+      "iteration": 1577045029184,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "datasource": "${DS_OPENSHIFT_PROMETHEUS}",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 43,
+          "panels": [],
+          "title": "Current Alerts",
+          "type": "row"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorPrefix": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 7,
+            "x": 0,
+            "y": 1
+          },
+          "id": 30,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "(\n  count (\n    (kubelet_volume_stats_available_bytes {namespace=~\"(openshift-.*|kube-.*|default|logging)\"})\n    and\n    (predict_linear(kubelet_volume_stats_available_bytes {namespace=~\"(openshift-.*|kube-.*|default|logging)\"}[1d], 7 * 24 * 60 * 60) < 0)\n  )\n)\nor\nvector(0)",
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "alerts",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "1,1",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Infrastructure Namespace Volumes Full in Week Based on Daily Use Rate",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorPrefix": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 7,
+            "x": 7,
+            "y": 1
+          },
+          "id": 34,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "(\n  count (\n    (\n      (kubelet_volume_stats_available_bytes {namespace!~\"(openshift-.*|kube-.*|default|logging)\"})\n    )\n    and\n    (predict_linear(kubelet_volume_stats_available_bytes[1d], 7 * 24 * 60 * 60) < 0)\n  )\n)\nor\nvector(0)",
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "alerts",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "1,1",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "User Namespace Volumes Full in Week Based on Daily Use Rate",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "dashboardFilter": "",
+          "dashboardTags": [],
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "folderId": null,
+          "gridPos": {
+            "h": 6,
+            "w": 10,
+            "x": 14,
+            "y": 1
+          },
+          "id": 29,
+          "limit": 10,
+          "nameFilter": "",
+          "onlyAlertsOnDashboard": true,
+          "options": {},
+          "show": "current",
+          "sortOrder": 1,
+          "stateFilter": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Dashboard Alerts",
+          "type": "alertlist"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "#FF9830",
+            "#FF9830"
+          ],
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "decimals": 0,
+          "editable": false,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 7,
+            "x": 0,
+            "y": 4
+          },
+          "id": 12,
+          "interval": null,
+          "isNew": false,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 0,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "lineColor": "rgb(31, 120, 193)"
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "count (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes ) and (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )) >= ($pvc_percent_used_warning_threshold / 100)) or vector (0)",
+              "format": "time_series",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "1,1",
+          "title": "Running PVCs Above % Used Warning Threshold",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "#FF9830",
+            "#FF9830"
+          ],
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "decimals": 0,
+          "editable": false,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 7,
+            "x": 7,
+            "y": 4
+          },
+          "id": 6,
+          "interval": null,
+          "isNew": false,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 0,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "lineColor": "rgb(31, 120, 193)"
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "(max (sum by (exported_namespace) (pv_collector_unbound_pvc_count))) or (vector(0))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "1,1",
+          "title": "Unbound PVCs",
+          "type": "singlestat",
+          "valueFontSize": "200%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "collapsed": true,
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 7
+          },
+          "id": 32,
+          "panels": [
+            {
+              "cacheTimeout": null,
+              "columns": [
+                {
+                  "text": "Avg",
+                  "value": "avg"
+                }
+              ],
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "fontSize": "100%",
+              "gridPos": {
+                "h": 14,
+                "w": 7,
+                "x": 0,
+                "y": 2
+              },
+              "id": 38,
+              "links": [],
+              "options": {},
+              "pageSize": null,
+              "showHeader": true,
+              "sort": {
+                "col": 0,
+                "desc": true
+              },
+              "styles": [
+                {
+                  "alias": "Available",
+                  "colorMode": "row",
+                  "colors": [
+                    "rgba(50, 172, 45, 0.97)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(245, 54, 54, 0.9)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value",
+                  "thresholds": [
+                    "0",
+                    "0"
+                  ],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "Namespace",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "namespace",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "PVC",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "persistentvolumeclaim",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "decimals": 2,
+                  "pattern": "/.*/",
+                  "thresholds": [],
+                  "type": "hidden",
+                  "unit": "short"
+                }
+              ],
+              "targets": [
+                {
+                  "expr": "(\n  (\n    (kubelet_volume_stats_available_bytes {namespace=~\"(openshift-.*|kube-.*|default|logging)\"} ) \n    and\n    (predict_linear(kubelet_volume_stats_available_bytes {namespace=~\"(openshift-.*|kube-.*|default|logging)\"}[1w], 7 * 24 * 60 * 60) < 0)\n  )\n)",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "legendFormat": "",
+                  "refId": "A"
+                }
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Infrastructure Namespace Volumes Full in Week Based on Daily Use Rate - Current",
+              "transform": "table",
+              "type": "table"
+            },
+            {
+              "alert": {
+                "alertRuleTags": {},
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [
+                        0
+                      ],
+                      "type": "gt"
+                    },
+                    "operator": {
+                      "type": "and"
+                    },
+                    "query": {
+                      "params": [
+                        "A",
+                        "1h",
+                        "now"
+                      ]
+                    },
+                    "reducer": {
+                      "params": [],
+                      "type": "avg"
+                    },
+                    "type": "query"
+                  }
+                ],
+                "executionErrorState": "alerting",
+                "for": "24h",
+                "frequency": "1h",
+                "handler": 1,
+                "name": "Infrastructure Namespace Volumes Full in Week Based on Daily Use Rate Alert",
+                "noDataState": "ok",
+                "notifications": []
+              },
+              "aliasColors": {},
+              "bars": true,
+              "cacheTimeout": null,
+              "dashLength": 10,
+              "dashes": false,
+              "fill": 10,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 17,
+                "x": 7,
+                "y": 2
+              },
+              "hiddenSeries": false,
+              "id": 45,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": false,
+              "linewidth": 2,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "(\n  (\n    ((kubelet_volume_stats_used_bytes {namespace=~\"(openshift-.*|kube-.*|default|logging)\"} ) * 0) + 1\n    and\n    (predict_linear(kubelet_volume_stats_available_bytes {namespace=~\"(openshift-.*|kube-.*|default|logging)\"}[1d], 7 * 24 * 60 * 60) < 0)\n  )\n)",
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [
+                {
+                  "colorMode": "critical",
+                  "fill": true,
+                  "line": true,
+                  "op": "gt",
+                  "value": 0
+                }
+              ],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Infrastructure Namespace Volumes Full in Week Based on Daily Use Rate - Alert History",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "short",
+                  "label": "# of Alerts",
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "cacheTimeout": null,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 17,
+                "x": 7,
+                "y": 9
+              },
+              "hiddenSeries": false,
+              "id": 27,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(\n  (predict_linear(kubelet_volume_stats_available_bytes {namespace=~\"(openshift-.*|kube-.*|default|logging)\"}[1d], 7 * 24 * 60 * 60) < 0)\n)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Infrastructure Namespace Volumes Full in Week Based on Daily Use Rate - Predicted Available Space History",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "bytes",
+                  "label": "1 Week Predicted Available Space",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "cacheTimeout": null,
+              "columns": [
+                {
+                  "text": "Avg",
+                  "value": "avg"
+                }
+              ],
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "fontSize": "100%",
+              "gridPos": {
+                "h": 13,
+                "w": 7,
+                "x": 0,
+                "y": 16
+              },
+              "id": 39,
+              "links": [],
+              "options": {},
+              "pageSize": null,
+              "showHeader": true,
+              "sort": {
+                "col": 0,
+                "desc": true
+              },
+              "styles": [
+                {
+                  "alias": "Available",
+                  "colorMode": "row",
+                  "colors": [
+                    "rgba(50, 172, 45, 0.97)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(245, 54, 54, 0.9)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "Value",
+                  "thresholds": [
+                    "0",
+                    "0"
+                  ],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "Namespace",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "namespace",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "PVC",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "mappingType": 1,
+                  "pattern": "persistentvolumeclaim",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "",
+                  "colorMode": null,
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "decimals": 2,
+                  "pattern": "/.*/",
+                  "thresholds": [],
+                  "type": "hidden",
+                  "unit": "short"
+                }
+              ],
+              "targets": [
+                {
+                  "expr": "(\n  (\n    (\n      (kubelet_volume_stats_used_bytes {namespace!~\"(openshift-.*|kube-.*|default|logging)\"})\n    )\n    and\n    (predict_linear(kubelet_volume_stats_available_bytes[1d], 7 * 24 * 60 * 60) < 0)\n  )\n)",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "legendFormat": "",
+                  "refId": "A"
+                }
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "User Namespace Volumes Full in Week Based on Daily Use Rate - Current",
+              "transform": "table",
+              "type": "table"
+            },
+            {
+              "alert": {
+                "alertRuleTags": {},
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [
+                        0
+                      ],
+                      "type": "gt"
+                    },
+                    "operator": {
+                      "type": "and"
+                    },
+                    "query": {
+                      "params": [
+                        "A",
+                        "1h",
+                        "now"
+                      ]
+                    },
+                    "reducer": {
+                      "params": [],
+                      "type": "avg"
+                    },
+                    "type": "query"
+                  }
+                ],
+                "executionErrorState": "alerting",
+                "for": "24h",
+                "frequency": "1h",
+                "handler": 1,
+                "name": "User Namespace Volumes Full in Week Based on Daily Use Rate Alert",
+                "noDataState": "ok",
+                "notifications": []
+              },
+              "aliasColors": {},
+              "bars": true,
+              "cacheTimeout": null,
+              "dashLength": 10,
+              "dashes": false,
+              "fill": 10,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 6,
+                "w": 17,
+                "x": 7,
+                "y": 16
+              },
+              "hiddenSeries": false,
+              "id": 40,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": false,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "(\n  (\n    (\n      (\n        (kubelet_volume_stats_used_bytes {namespace!~\"(openshift-.*|kube-.*|default|logging)\"})\n      )\n      * 0 + 1\n    )\n    and\n    (predict_linear(kubelet_volume_stats_available_bytes[1d], 7 * 24 * 60 * 60) < 0)\n  )\n)",
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [
+                {
+                  "colorMode": "critical",
+                  "fill": true,
+                  "line": true,
+                  "op": "gt",
+                  "value": 0
+                }
+              ],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "User Namespace Volumes Full in Week Based on Daily Use Rate - Alert History",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "short",
+                  "label": "# of Alerts",
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "cacheTimeout": null,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 7,
+                "w": 17,
+                "x": 7,
+                "y": 22
+              },
+              "hiddenSeries": false,
+              "id": 46,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(\n  (predict_linear(kubelet_volume_stats_available_bytes {namespace!~\"(openshift-.*|kube-.*|default|logging)\"}[1d], 7 * 24 * 60 * 60) < 0)\n)",
+                  "format": "time_series",
+                  "hide": false,
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "User Namespace Volumes Full in Week Based on Daily Use Rate - Predicted Available Space History",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "bytes",
+                  "label": "1 Week Predicted Available Space",
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "columns": [],
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "editable": false,
+              "error": false,
+              "fontSize": "100%",
+              "gridPos": {
+                "h": 6,
+                "w": 7,
+                "x": 0,
+                "y": 29
+              },
+              "id": 9,
+              "isNew": false,
+              "options": {},
+              "pageSize": null,
+              "scroll": false,
+              "showHeader": true,
+              "sort": {
+                "col": 16,
+                "desc": true
+              },
+              "span": 0,
+              "styles": [
+                {
+                  "alias": "Used",
+                  "colorMode": "row",
+                  "colors": [
+                    "#73BF69",
+                    "#FF9830",
+                    "#FF9830"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "pattern": "Value #A",
+                  "thresholds": [
+                    "0",
+                    "0"
+                  ],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "Capacity",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "pattern": "Value #B",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "Free",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "pattern": "Value #C",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "% Used",
+                  "colors": [
+                    "rgba(50, 172, 45, 0.97)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(245, 54, 54, 0.9)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "Value #D",
+                  "thresholds": [
+                    "($pvc_percent_used_warning_threshold / 100)",
+                    ".9"
+                  ],
+                  "type": "number",
+                  "unit": "percentunit"
+                },
+                {
+                  "alias": "StorageClass",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "storageclass",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "PV",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "volumename",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "Namespace",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "namespace",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "PVC",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "persistentvolumeclaim",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "Volume Stats Exist?",
+                  "colorMode": "value",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "Value #F",
+                  "thresholds": [
+                    "1",
+                    "1"
+                  ],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "/.*/",
+                  "thresholds": [],
+                  "type": "hidden",
+                  "unit": "short"
+                }
+              ],
+              "targets": [
+                {
+                  "expr": "(kube_persistentvolumeclaim_info) and ((max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )) >= ($pvc_percent_used_warning_threshold / 100))",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "E"
+                },
+                {
+                  "expr": "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes)) and ((max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )) >= ($pvc_percent_used_warning_threshold / 100))",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "refId": "A"
+                },
+                {
+                  "expr": "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )) and ((max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )) >= ($pvc_percent_used_warning_threshold / 100))",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "B"
+                },
+                {
+                  "expr": "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_available_bytes )) and ((max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )) >= ($pvc_percent_used_warning_threshold / 100))",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "C"
+                },
+                {
+                  "expr": "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )) >= ($pvc_percent_used_warning_threshold / 100)",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "D"
+                }
+              ],
+              "title": "Running PVCs Above % Used Warning Threshold Stats - Current",
+              "transform": "table",
+              "type": "table"
+            },
+            {
+              "aliasColors": {},
+              "bars": true,
+              "cacheTimeout": null,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "fill": 5,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 6,
+                "w": 17,
+                "x": 7,
+                "y": 29
+              },
+              "hiddenSeries": false,
+              "id": 41,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": false,
+                "total": false,
+                "values": false
+              },
+              "lines": false,
+              "linewidth": 1,
+              "links": [],
+              "nullPointMode": "null as zero",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": true,
+              "steppedLine": true,
+              "targets": [
+                {
+                  "expr": "(\n  ((max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) * 0 +1)\n  and\n  (\n    (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes ))\n  ) >= ($pvc_percent_used_warning_threshold / 100)\n)",
+                  "format": "time_series",
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Running PVCs Above % Used Warning Threshold - History",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": 0,
+                  "format": "short",
+                  "label": "# of Alerts",
+                  "logBase": 1,
+                  "max": null,
+                  "min": "0",
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "title": "Alert Details",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "id": 20,
+          "panels": [
+            {
+              "cacheTimeout": null,
+              "colorBackground": false,
+              "colorValue": false,
+              "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+              ],
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "decimals": 0,
+              "editable": false,
+              "error": false,
+              "format": "none",
+              "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 2,
+                "x": 0,
+                "y": 3
+              },
+              "id": 4,
+              "interval": null,
+              "isNew": false,
+              "links": [],
+              "mappingType": 1,
+              "mappingTypes": [
+                {
+                  "name": "value to text",
+                  "value": 1
+                },
+                {
+                  "name": "range to text",
+                  "value": 2
+                }
+              ],
+              "maxDataPoints": 100,
+              "nullPointMode": "connected",
+              "nullText": null,
+              "options": {},
+              "postfix": "",
+              "postfixFontSize": "50%",
+              "prefix": "",
+              "prefixFontSize": "50%",
+              "rangeMaps": [
+                {
+                  "from": "null",
+                  "text": "N/A",
+                  "to": "null"
+                }
+              ],
+              "span": 0,
+              "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "lineColor": "rgb(31, 120, 193)"
+              },
+              "tableColumn": "",
+              "targets": [
+                {
+                  "expr": "(sum (pv_collector_bound_pvc_count)) or vector(0)",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "A"
+                }
+              ],
+              "thresholds": "",
+              "title": "Bound PVCs",
+              "type": "singlestat",
+              "valueFontSize": "200%",
+              "valueMaps": [
+                {
+                  "op": "=",
+                  "text": "N/A",
+                  "value": "null"
+                }
+              ],
+              "valueName": "current"
+            },
+            {
+              "columns": [],
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "editable": false,
+              "error": false,
+              "fontSize": "100%",
+              "gridPos": {
+                "h": 25,
+                "w": 24,
+                "x": 0,
+                "y": 7
+              },
+              "id": 10,
+              "isNew": false,
+              "links": [
+                {
+                  "includeVars": false,
+                  "title": "OpenShift Container Storage (OCS) 3.11: Operations Guide: 10.1. Available Metrics for File Storage and Block Storage",
+                  "type": "",
+                  "url": "https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.11/html/operations_guide/enable_vol_metrics#file_vol_metrics"
+                }
+              ],
+              "options": {},
+              "pageSize": null,
+              "scroll": false,
+              "showHeader": true,
+              "sort": {
+                "col": 16,
+                "desc": true
+              },
+              "span": 0,
+              "styles": [
+                {
+                  "alias": "Used",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "pattern": "Value #A",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "Capacity",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "pattern": "Value #B",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "Free",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "pattern": "Value #C",
+                  "thresholds": [],
+                  "type": "number",
+                  "unit": "bytes"
+                },
+                {
+                  "alias": "% Used",
+                  "colorMode": "cell",
+                  "colors": [
+                    "rgba(50, 172, 45, 0.97)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(245, 54, 54, 0.9)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "Value #D",
+                  "thresholds": [
+                    ".8",
+                    ".9"
+                  ],
+                  "type": "number",
+                  "unit": "percentunit"
+                },
+                {
+                  "alias": "StorageClass",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "storageclass",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "PV",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "volumename",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "Namespace",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "namespace",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "PVC",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "persistentvolumeclaim",
+                  "thresholds": [],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "Volume Stats Exist?",
+                  "colorMode": "value",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "Value #F",
+                  "thresholds": [
+                    "1",
+                    "1"
+                  ],
+                  "type": "string",
+                  "unit": "short"
+                },
+                {
+                  "alias": "",
+                  "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                  ],
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "decimals": 2,
+                  "pattern": "/.*/",
+                  "thresholds": [],
+                  "type": "hidden",
+                  "unit": "short"
+                }
+              ],
+              "targets": [
+                {
+                  "expr": "kube_persistentvolumeclaim_info",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "E"
+                },
+                {
+                  "expr": "(1-max by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_info ) ) unless (max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes )) or ((max by (persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_info ) ) and (max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes )))",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "F"
+                },
+                {
+                  "expr": "max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes)",
+                  "format": "table",
+                  "instant": true,
+                  "intervalFactor": 1,
+                  "refId": "A"
+                },
+                {
+                  "expr": "max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "B"
+                },
+                {
+                  "expr": "max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_available_bytes )",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "C"
+                },
+                {
+                  "expr": "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes ))",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "D"
+                }
+              ],
+              "title": "PVC Stats",
+              "transform": "table",
+              "type": "table"
+            }
+          ],
+          "title": "Stats",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 22,
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "description": "WARNING: Any PVCs that are not bound to a running pod will not show up in this state.",
+              "editable": false,
+              "error": false,
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 4
+              },
+              "hiddenSeries": false,
+              "id": 15,
+              "isNew": false,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 0,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes ))",
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "All Running PVCs Used Bytes",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "format": "",
+                "logBase": 0,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "bytes",
+                  "logBase": 1,
+                  "show": true
+                },
+                {
+                  "format": "bytes",
+                  "logBase": 1,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "description": "WARNING: Any PVCs that are not bound to a running pod will not show up in this state.",
+              "editable": false,
+              "error": false,
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 12
+              },
+              "hiddenSeries": false,
+              "id": 14,
+              "isNew": false,
+              "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "span": 0,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes )) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes )) * 100",
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Running PVCs % Used",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "format": "",
+                "logBase": 0,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "percent",
+                  "logBase": 1,
+                  "max": 100,
+                  "min": 0,
+                  "show": true
+                },
+                {
+                  "format": "bytes",
+                  "logBase": 1,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "title": "Use",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 10
+          },
+          "id": 24,
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "description": "WARNING: Any PVCs that are not bound to a running pod will not show up in this state.",
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 5
+              },
+              "hiddenSeries": false,
+              "id": 17,
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(kubelet_volume_stats_used_bytes [1h])",
+                  "format": "time_series",
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Hourly Volume Use Rate",
+              "tooltip": {
+                "shared": true,
+                "sort": 1,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": null,
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "description": "WARNING: Any PVCs that are not bound to a running pod will not show up in this state.",
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 11
+              },
+              "hiddenSeries": false,
+              "id": 18,
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(kubelet_volume_stats_used_bytes [1d])",
+                  "format": "time_series",
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Daily Volume Use Rate",
+              "tooltip": {
+                "shared": true,
+                "sort": 1,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": null,
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$DS_OPENSHIFT_PROMETHEUS",
+              "description": "WARNING: Any PVCs that are not bound to a running pod will not show up in this state.",
+              "fill": 0,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 17
+              },
+              "hiddenSeries": false,
+              "hideTimeOverride": false,
+              "id": 25,
+              "interval": "",
+              "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": true
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "options": {
+                "dataLinks": []
+              },
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "rate(kubelet_volume_stats_used_bytes [1w])",
+                  "format": "time_series",
+                  "instant": false,
+                  "intervalFactor": 1,
+                  "legendFormat": "{{ "{{" }}namespace{{ "}}" }} ({{ "{{" }}persistentvolumeclaim{{ "}}" }})",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Weekly Volume Use Rate",
+              "tooltip": {
+                "shared": true,
+                "sort": 1,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "decimals": null,
+                  "format": "bytes",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "title": "Use Rate",
+          "type": "row"
+        }
+      ],
+      "schemaVersion": 21,
+      "style": "dark",
+      "tags": [
+        "openshift",
+        "k8s",
+        "storage"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allFormat": "",
+            "allValue": "",
+            "current": {
+              "text": "openshift-prometheus",
+              "value": "openshift-prometheus"
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "multiFormat": "",
+            "name": "DS_OPENSHIFT_PROMETHEUS",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "datasource"
+          },
+          {
+            "allFormat": "",
+            "allValue": "",
+            "current": {
+              "selected": false,
+              "text": "80",
+              "value": "80"
+            },
+            "datasource": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "PVC % Used Warning Threshold",
+            "multi": false,
+            "multiFormat": "",
+            "name": "pvc_percent_used_warning_threshold",
+            "options": [
+              {
+                "selected": false,
+                "text": "80",
+                "value": "80"
+              }
+            ],
+            "query": "80",
+            "refresh": false,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "textbox"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-2d",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": null
+      },
+      "timezone": "",
+      "title": "K8s / Storage / Volumes / Cluster"
+    }

--- a/sources/otel-lgtm-stack/v1.0.8/templates/dashboards-gpu.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/dashboards-gpu.yaml
@@ -1,0 +1,1104 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lgtm-amd-gpu-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+     grafana_dashboard: "1"
+  annotations:
+     grafana_folder: "common"
+data:
+  amd-gpu-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 1,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 0,
+            "y": 0
+          },
+          "id": 10,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "**GPU MODEL**\n## ${gpu_model}\n\n**GPU S/N**\n## ${gpu_serial_number}",
+            "mode": "markdown"
+          },
+          "pluginVersion": "11.1.4",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "watt"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 4,
+            "y": 0
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^gpu_power_usage$/",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "gpu_power_usage{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "gpu_power_usage",
+              "range": false,
+              "refId": "gpu_power_usage",
+              "useBackend": false
+            }
+          ],
+          "title": "Power Usage (W)",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "reduce",
+              "options": {
+                "includeTimeField": false,
+                "mode": "reduceFields",
+                "reducers": [
+                  "mean"
+                ]
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 9,
+            "y": 0
+          },
+          "id": 4,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "gpu_used_vram{gpu_uuid=~\"$gpu\", job=\"$scope\"} / on(gpu_uuid) gpu_total_vram{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "gpu_vram_utilization",
+              "range": false,
+              "refId": "gpu_used_vram",
+              "useBackend": false
+            }
+          ],
+          "title": "Memory Utilization %",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "Time",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "reduce",
+              "options": {
+                "reducers": [
+                  "mean"
+                ]
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 14,
+            "y": 0
+          },
+          "id": 12,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^gpu_gfx_activity$/",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "gpu_gfx_activity{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "gpu_gfx_activity",
+              "range": false,
+              "refId": "gpu_gfx_activity",
+              "useBackend": false
+            }
+          ],
+          "title": "GPU Utilization %",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "reduce",
+              "options": {
+                "includeTimeField": false,
+                "mode": "reduceFields",
+                "reducers": [
+                  "mean"
+                ]
+              }
+            }
+          ],
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 19,
+            "y": 0
+          },
+          "id": 9,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "gpu_edge_temperature{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "gpu_edge_temperature",
+              "range": false,
+              "refId": "gpu_edge_temperature",
+              "useBackend": false
+            }
+          ],
+          "title": "GPU Temperature °C",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "reduce",
+              "options": {
+                "includeTimeField": false,
+                "labelsToFields": false,
+                "mode": "seriesToRows",
+                "reducers": [
+                  "mean"
+                ]
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 5,
+            "x": 4,
+            "y": 3
+          },
+          "id": 13,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^gpu_used_vram$/",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "gpu_used_vram{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "gpu_used_vram",
+              "range": false,
+              "refId": "gpu_used_vram",
+              "useBackend": false
+            }
+          ],
+          "title": "VRAM Usage (MB)",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "reduce",
+              "options": {
+                "includeTimeField": false,
+                "mode": "reduceFields",
+                "reducers": [
+                  "mean"
+                ]
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 6
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "gpu_gfx_activity{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{ "{{" }}gpu_uuid{{ "}}" }}",
+              "range": true,
+              "refId": "gpu_gfx_activity",
+              "useBackend": false
+            }
+          ],
+          "title": "GPU Utilization %",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 1,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 6
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "gpu_used_vram{gpu_uuid=~\"$gpu\", job=\"$scope\"} / on(gpu_uuid) gpu_total_vram{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "gpu_used_vram",
+              "useBackend": false
+            }
+          ],
+          "title": "Memory Utilization %",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "celsius"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 6
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "exemplar": false,
+              "expr": "gpu_edge_temperature{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{ "{{" }}gpu_uuid{{ "}}" }}",
+              "range": true,
+              "refId": "gpu_edge_temperature",
+              "useBackend": false
+            }
+          ],
+          "title": "GPU Temperature °C",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto",
+                  "wrapText": false
+                },
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 13
+          },
+          "id": 14,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.1.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "{gpu_uuid=~\"$gpu\", job=\"$scope\"}",
+              "format": "table",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Raw data",
+          "type": "table"
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "kubernetes-pods",
+              "value": "kubernetes-pods"
+            },
+            "description": "Filter variable for job scope",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Scope",
+            "multi": false,
+            "name": "scope",
+            "options": [
+              {
+                "selected": true,
+                "text": "kubernetes-pods",
+                "value": "kubernetes-pods"
+              },
+              {
+                "selected": false,
+                "text": "kubernetes-service-endpoints",
+                "value": "kubernetes-service-endpoints"
+              }
+            ],
+            "query": "kubernetes-pods,kubernetes-service-endpoints",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "atlpkuc4app06",
+              "value": "atlpkuc4app06"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(node)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Node",
+            "multi": false,
+            "name": "node",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(node)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values({node=\"$node\"},gpu_uuid)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "GPU",
+            "multi": false,
+            "name": "gpu",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values({node=\"$node\"},gpu_uuid)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "current": {
+              "isNone": true,
+              "selected": false,
+              "text": "None",
+              "value": ""
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values({gpu_uuid=\"$gpu\"},amd_com_gpu_family)",
+            "hide": 2,
+            "includeAll": false,
+            "label": "GPU Family",
+            "multi": false,
+            "name": "gpu_family",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values({gpu_uuid=\"$gpu\"},amd_com_gpu_family)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": [
+                "102-D65210-00"
+              ],
+              "value": [
+                "102-D65210-00"
+              ]
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values({gpu_uuid=~\"$gpu\"},card_model)",
+            "hide": 2,
+            "includeAll": false,
+            "label": "GPU Model",
+            "multi": true,
+            "name": "gpu_model",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values({gpu_uuid=~\"$gpu\"},card_model)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": [
+                "692324000620"
+              ],
+              "value": [
+                "692324000620"
+              ]
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values({gpu_uuid=~\"$gpu\"},serial_number)",
+            "hide": 2,
+            "includeAll": false,
+            "label": "GPU Serial Number",
+            "multi": true,
+            "name": "gpu_serial_number",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values({gpu_uuid=~\"$gpu\"},serial_number)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "AMD GPU Metrics",
+      "uid": "ee6sumbzuzl6oc",
+      "version": 25,
+      "weekStart": ""
+    }

--- a/sources/otel-lgtm-stack/v1.0.8/templates/grafana-externalsecret.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/grafana-externalsecret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-admin-credentials
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao-secret-store
+  target:
+    creationPolicy: Owner
+    name: grafana-admin-credentials
+  data:
+    - secretKey: username
+      remoteRef:
+        key: grafana-admin-user
+        property: value
+    - secretKey: password
+      remoteRef:
+        key: grafana-admin-password
+        property: value

--- a/sources/otel-lgtm-stack/v1.0.8/templates/grafana-httproute.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/grafana-httproute.yaml
@@ -1,0 +1,31 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier: MIT
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana-route
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: https
+      namespace: envoy-gateway-system
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: lgtm-stack
+          port: {{ .Values.services.lgtm.grafana }}
+          weight: 1
+      matches:
+        - headers:
+            - name: Host
+              type: RegularExpression
+              value: grafana\..*
+          path:
+            type: PathPrefix
+            value: /

--- a/sources/otel-lgtm-stack/v1.0.8/templates/kube-state-metrics.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/kube-state-metrics.yaml
@@ -1,0 +1,306 @@
+---
+# Source: kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: my-kube-state-metrics
+    app.kubernetes.io/version: "2.15.0"
+  name: my-kube-state-metrics
+  namespace: {{ .Release.Namespace }}
+---
+# Source: kube-state-metrics/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: my-kube-state-metrics
+    app.kubernetes.io/version: "2.15.0"
+  name: my-kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - volumeattachments
+  verbs: ["list", "watch"]
+---
+# Source: kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: my-kube-state-metrics
+    app.kubernetes.io/version: "2.15.0"
+  name: my-kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: my-kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: my-kube-state-metrics
+  namespace: {{ .Release.Namespace }}
+---
+# Source: kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-kube-state-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: my-kube-state-metrics
+    app.kubernetes.io/version: "2.15.0"
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: "http"
+    protocol: TCP
+    port: {{ .Values.services.kubeStateMetrics.http }}
+    targetPort: {{ .Values.services.kubeStateMetrics.http }}
+  
+  selector:    
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: my-kube-state-metrics
+---
+# Source: kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-kube-state-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.30.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: my-kube-state-metrics
+    app.kubernetes.io/version: "2.15.0"
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: my-kube-state-metrics
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:        
+        helm.sh/chart: kube-state-metrics-5.30.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: kube-state-metrics
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: my-kube-state-metrics
+        app.kubernetes.io/version: "2.15.0"
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: false
+      serviceAccountName: my-kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: kube-state-metrics
+        args:
+        - --port=8080
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        imagePullPolicy: IfNotPresent
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        ports:
+        - containerPort: 8080
+          name: "http"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /livez
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true

--- a/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
@@ -354,7 +354,7 @@ spec:
                   curl -f http://localhost:9090/-/ready &&
                   curl -f http://localhost:3100/ready &&
                   curl -f http://localhost:3000/api/health
-            initialDelaySeconds: 180
+            initialDelaySeconds: 60
             periodSeconds: 15
             timeoutSeconds: 10
             failureThreshold: 2
@@ -368,7 +368,7 @@ spec:
                   curl -f http://localhost:3100/ready &&
                   curl -f http://localhost:3000/api/health &&
                   /scripts/check-ps.sh
-            initialDelaySeconds: 180
+            initialDelaySeconds: 120
             periodSeconds: 30
             timeoutSeconds: 15
             failureThreshold: 3

--- a/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
@@ -323,8 +323,7 @@ spec:
             - name: sc-dashboard-volume
               mountPath: "/tmp/dashboards"
         - name: lgtm
-          image: grafana/otel-lgtm:0.29.2
-          command: ["/bin/bash", "-c", "/otel-lgtm/run-all.sh && tail -f /dev/null"]
+          image: ghcr.io/silogen/docker-otel-lgtm:v1.0.7 
           env:
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "false"
@@ -369,7 +368,7 @@ spec:
                   curl -f http://localhost:3100/ready &&
                   curl -f http://localhost:3000/api/health &&
                   /scripts/check-ps.sh
-            initialDelaySeconds: 120
+            initialDelaySeconds: 180
             periodSeconds: 30
             timeoutSeconds: 15
             failureThreshold: 3

--- a/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
@@ -106,19 +106,14 @@ data:
         exit 1
     fi
 
-    # Define required processes
+    # Define required processes (only actual services, not wrapper scripts)
     REQUIRED_PROCESSES=(
-        "/bin/bash /otel-lgtm/run-all.sh"
-        "/bin/bash ./run-loki.sh"
-        "/bin/bash ./run-grafana.sh"
         "./bin/grafana server"
-        "/bin/bash ./run-otelcol.sh"
-        "/bin/bash ./run-prometheus.sh"
         "./otelcol-contrib/otelcol-contrib --feature-gates service.profilesSupport --config=file:./otelcol-config.yaml"
         "./loki/loki --config.file=./loki-config.yaml"
-        "/bin/bash ./run-tempo.sh"
-        "./prometheus/prometheus --web.enable-remote-write-receiver --web.enable-otlp-receiver --enable-feature=exemplar-storage --enable-feature=native-histograms --storage.tsdb.path=/data/prometheus --config.file=./prometheus.yaml"
-        "/data/grafana/plugins/grafana-llm-app/gpx_llm_linux_amd64"
+        "./prometheus/prometheus --web.enable-remote-write-receiver --web.enable-otlp-receiver --enable-feature=exemplar-storage --storage.tsdb.path=/data/prometheus --config.file=./prometheus.yaml"
+        "./tempo/tempo --config.file=./tempo-config.yaml"
+        "./pyroscope/pyroscope --config.file=./pyroscope-config.yaml"
     )
 
     # Check each process and build list of missing ones

--- a/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
@@ -323,7 +323,7 @@ spec:
             - name: sc-dashboard-volume
               mountPath: "/tmp/dashboards"
         - name: lgtm
-          image: ghcr.io/silogen/docker-otel-lgtm:v1.0.7 
+          image: grafana/otel-lgtm:0.29.2
           env:
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "false"

--- a/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml
@@ -1,0 +1,455 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  name: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tempo-pvc
+  namespace: {{ .Release.Namespace }}
+spec:
+  storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.lgtm.storage.tempo }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-data-pvc
+  namespace: {{ .Release.Namespace }}
+spec:
+  storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.lgtm.storage.loki }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-storage-pvc
+  namespace: {{ .Release.Namespace }}
+spec:
+  storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.lgtm.storage.extra }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-pvc
+  namespace: {{ .Release.Namespace }}
+spec:
+  storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.lgtm.storage.grafana }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: p8s-pvc
+  namespace: {{ .Release.Namespace }}
+spec:
+  storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.lgtm.storage.mimir }}
+---
+# Source: grafana/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-sidecar
+  namespace: {{ .Release.Namespace }}
+---
+# ConfigMap for liveness/readiness check script
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lgtm-check-scripts
+  namespace: {{ .Release.Namespace }}
+data:
+  check-ps.sh: |
+    #!/bin/sh
+    # Get processes using /proc filesystem (runs inside container)
+    PROCESS_LIST=""
+    for pid in /proc/[0-9]*; do
+        cmdline=$(cat "$pid/cmdline" 2>/dev/null | tr "\0" " ")
+        if [ -n "$cmdline" ]; then
+            PROCESS_LIST="${PROCESS_LIST}${cmdline}"$'\n'
+        fi
+    done
+
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+
+    if [[ -z "$PROCESS_LIST" ]]; then
+        echo -e "${RED}[FAILED] Could not retrieve process list from container${NC}"
+        exit 1
+    fi
+
+    # Define required processes
+    REQUIRED_PROCESSES=(
+        "/bin/bash /otel-lgtm/run-all.sh"
+        "/bin/bash ./run-loki.sh"
+        "/bin/bash ./run-grafana.sh"
+        "./bin/grafana server"
+        "/bin/bash ./run-otelcol.sh"
+        "/bin/bash ./run-prometheus.sh"
+        "./otelcol-contrib/otelcol-contrib --feature-gates service.profilesSupport --config=file:./otelcol-config.yaml"
+        "./loki/loki --config.file=./loki-config.yaml"
+        "/bin/bash ./run-tempo.sh"
+        "./prometheus/prometheus --web.enable-remote-write-receiver --web.enable-otlp-receiver --enable-feature=exemplar-storage --enable-feature=native-histograms --storage.tsdb.path=/data/prometheus --config.file=./prometheus.yaml"
+        "/data/grafana/plugins/grafana-llm-app/gpx_llm_linux_amd64"
+    )
+
+    # Check each process and build list of missing ones
+    MISSING_COUNT=0
+    echo "Expected processes (${#REQUIRED_PROCESSES[@]} total):"
+    echo "---"
+
+    for REQUIRED in "${REQUIRED_PROCESSES[@]}"; do
+        if echo "$PROCESS_LIST" | grep -qF "$REQUIRED"; then
+            echo -e "${GREEN}  [RUNNING] $REQUIRED${NC}"
+        else
+            echo -e "${RED}  [MISSING] $REQUIRED${NC}"
+            MISSING_COUNT=$((MISSING_COUNT + 1))
+        fi
+    done
+
+    echo ""
+
+    if [[ $MISSING_COUNT -eq 0 ]]; then
+        echo -e "${GREEN}  [OK] All required processes are running${NC}"
+    else
+        echo -e "${RED}  [WARNING] $MISSING_COUNT of ${#REQUIRED_PROCESSES[@]} processes are missing${NC}"
+        echo ""
+        echo -e "${YELLOW}  This may indicate the LGTM stack is not fully operational.${NC}"
+        echo -e "${YELLOW}  Consider restarting the pod.${NC}"
+    fi
+
+    echo ""
+
+    if [[ $MISSING_COUNT -gt 0 ]]; then
+        echo -e "${RED}[FAILED] Some required processes are not running${NC}"
+        exit 1
+    fi
+    exit 0
+
+---
+# Source: grafana/templates/configmap-dashboard-provider.yaml ######
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+  name: grafana-config-dashboards
+  namespace: {{ .Release.Namespace }}
+data:
+  provider.yaml: |-
+    apiVersion: 1
+    providers:
+      - name: 'sidecarProvider'
+        orgId: 1
+        type: file
+        disableDeletion: false
+        allowUiUpdates: false
+        updateIntervalSeconds: 30
+        options:
+          foldersFromFilesStructure: true
+          path: /tmp/dashboards
+---
+# Source: grafana/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: grafana-sidecar-clusterrole
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "watch", "list"]
+---
+# Source: grafana/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: lgtm-grafana-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: grafana-sidecar
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: grafana-sidecar-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+---
+# this is intended for demo / testing purposes only, not for production usage
+apiVersion: v1
+kind: Service
+metadata:
+  name: lgtm-stack
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: lgtm
+  ports:
+    - name: grafana
+      protocol: TCP
+      port: {{ .Values.services.lgtm.grafana }}
+      targetPort: {{ .Values.services.lgtm.grafana }}
+    - name: otel-grpc
+      protocol: TCP
+      port: {{ .Values.services.lgtm.otelGrpc }}
+      targetPort: {{ .Values.services.lgtm.otelGrpc }}
+    - name: otel-http
+      protocol: TCP
+      port: {{ .Values.services.lgtm.otelHttp }}
+      targetPort: {{ .Values.services.lgtm.otelHttp }}
+    - name: prometheus
+      protocol: TCP
+      port: {{ .Values.services.lgtm.prometheus }}
+      targetPort: {{ .Values.services.lgtm.prometheus }}
+    - name: loki
+      protocol: TCP
+      port: {{ .Values.services.lgtm.loki }}
+      targetPort: {{ .Values.services.lgtm.loki }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lgtm
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: lgtm
+  template:
+    metadata:
+      annotations:
+        # Roll out new pods when the overridden config content changes.
+        # subPath mounts do not hot-reload, so a content change must restart the pod.
+        checksum/loki-config: {{ .Values.lgtm.configOverrides.lokiConfig | sha256sum }}
+        checksum/otelcol-config: {{ .Values.lgtm.configOverrides.otelcolConfig | sha256sum }}
+      labels:
+        app: lgtm
+    spec:
+      serviceAccountName: grafana-sidecar
+      automountServiceAccountToken: true
+      {{- if and .Values.dashboards.enabled .Values.dashboards.github.enabled (gt (len .Values.dashboards.github.urls) 0) }}
+      initContainers:
+        - name: grafana-github-dashboards
+          image: {{ .Values.dashboards.github.image | quote }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              set -eu
+              target_dir="/tmp/dashboards/{{ .Values.dashboards.github.folder }}"
+              mkdir -p "$target_dir"
+              i=1
+              {{- range $url := .Values.dashboards.github.urls }}
+              if curl -fsSL {{ $url | quote }} -o "$target_dir/dashboard-$i.json"; then
+                echo "Downloaded dashboard $i"
+              else
+                echo "WARN: failed to download dashboard $i from {{ $url }}"
+              fi
+              i=$((i+1))
+              {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: sc-dashboard-volume
+              mountPath: /tmp/dashboards
+      {{- end }}
+      containers:
+        - name: grafana-sc-dashboard
+          image: "quay.io/kiwigrid/k8s-sidecar:1.27.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: METHOD
+              value: WATCH
+            - name: LABEL
+              value: "grafana_dashboard"
+            - name: FOLDER
+              value: "/tmp/dashboards" ##
+            - name: RESOURCE
+              value: "both"
+            - name: FOLDER_ANNOTATION
+              value: "grafana_folder"
+            - name: REQ_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin-credentials
+                  key: username
+            - name: REQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin-credentials
+                  key: password
+            - name: REQ_URL
+              value: http://localhost:3000/api/admin/provisioning/dashboards/reload
+            - name: REQ_METHOD
+              value: POST
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts: ##
+            - name: sc-dashboard-volume
+              mountPath: "/tmp/dashboards"
+        - name: lgtm
+          image: grafana/otel-lgtm:0.29.2
+          command: ["/bin/bash", "-c", "/otel-lgtm/run-all.sh && tail -f /dev/null"]
+          env:
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "false"
+            - name: GF_AUTH_BASIC_ENABLED
+              value: "true"
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin-credentials
+                  key: username
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin-credentials
+                  key: password
+          ports:
+            - containerPort: 3000
+            - containerPort: 4317
+            - containerPort: 4318
+            - containerPort: 9090
+            - containerPort: 3100
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  curl -f http://localhost:9090/-/ready &&
+                  curl -f http://localhost:3100/ready &&
+                  curl -f http://localhost:3000/api/health
+            initialDelaySeconds: 180
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 2
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  curl -f http://localhost:9090/-/ready &&
+                  curl -f http://localhost:3100/ready &&
+                  curl -f http://localhost:3000/api/health &&
+                  /scripts/check-ps.sh
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: {{ .Values.lgtm.resources.requests.cpu | quote }}
+              memory: {{ .Values.lgtm.resources.requests.memory | quote }}
+            limits:
+              memory: {{ .Values.lgtm.resources.limits.memory | quote }}
+          # NOTE: By default OpenShift does not allow writing the root directory.
+          # Thats why the data dirs for grafana, prometheus and loki can not be
+          # created and the pod never becomes ready.
+          # See: https://github.com/grafana/docker-otel-lgtm/issues/132
+          volumeMounts:
+            - name: tempo-data
+              mountPath: /data/tempo
+            - name: grafana-data
+              mountPath: /data/grafana
+            - name: loki-data
+              mountPath: /data/loki
+            - name: loki-storage
+              mountPath: /loki
+            - name: p8s-storage
+              mountPath: /data/prometheus
+            - name: sc-dashboard-volume ##
+              mountPath: "/tmp/dashboards"
+            - name: sc-dashboard-provider ##
+              mountPath: "/otel-lgtm/grafana/conf/provisioning/dashboards/sc-dashboardproviders.yaml"
+              subPath: provider.yaml
+            - name: check-scripts
+              mountPath: /scripts
+              readOnly: true
+            {{- if .Values.lgtm.configOverrides.lokiConfig }}
+            - name: loki-config
+              mountPath: /otel-lgtm/loki-config.yaml
+              subPath: loki-config.yaml
+            {{- end }}
+            {{- if .Values.lgtm.configOverrides.otelcolConfig }}
+            - name: otelcol-config
+              mountPath: /otel-lgtm/otelcol-config.yaml
+              subPath: otelcol-config.yaml
+            {{- end }}
+      volumes:
+        - name: tempo-data
+          persistentVolumeClaim:
+            claimName: tempo-pvc
+        - name: loki-data
+          persistentVolumeClaim:
+            claimName: loki-data-pvc
+        - name: grafana-data
+          persistentVolumeClaim:
+            claimName: grafana-pvc
+        - name: loki-storage
+          persistentVolumeClaim:
+            claimName: loki-storage-pvc
+        - name: p8s-storage
+          persistentVolumeClaim:
+            claimName: p8s-pvc
+        - name: sc-dashboard-volume ##
+          emptyDir:
+            {}
+        - name: sc-dashboard-provider ##
+          configMap:
+            name: grafana-config-dashboards
+        - name: check-scripts
+          configMap:
+            name: lgtm-check-scripts
+            defaultMode: 493
+        {{- if .Values.lgtm.configOverrides.lokiConfig }}
+        - name: loki-config
+          configMap:
+            name: lgtm-loki-config
+        {{- end }}
+        {{- if .Values.lgtm.configOverrides.otelcolConfig }}
+        - name: otelcol-config
+          configMap:
+            name: lgtm-otelcol-config
+        {{- end }}

--- a/sources/otel-lgtm-stack/v1.0.8/templates/node-exporter.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/templates/node-exporter.yaml
@@ -1,0 +1,171 @@
+---
+# Source: prometheus-node-exporter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodeexporter-prometheus-node-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: prometheus-node-exporter-4.44.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: prometheus-node-exporter
+    app.kubernetes.io/name: prometheus-node-exporter
+    app.kubernetes.io/instance: nodeexporter
+    app.kubernetes.io/version: "1.9.0"
+automountServiceAccountToken: false
+---
+# Source: prometheus-node-exporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodeexporter-prometheus-node-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: prometheus-node-exporter-4.44.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: prometheus-node-exporter
+    app.kubernetes.io/name: prometheus-node-exporter
+    app.kubernetes.io/instance: nodeexporter
+    app.kubernetes.io/version: "1.9.0"
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.services.nodeExporter.metrics }}
+      targetPort: {{ .Values.services.nodeExporter.metrics }}
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: prometheus-node-exporter
+    app.kubernetes.io/instance: nodeexporter
+---
+# Source: prometheus-node-exporter/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nodeexporter-prometheus-node-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: prometheus-node-exporter-4.44.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: prometheus-node-exporter
+    app.kubernetes.io/name: prometheus-node-exporter
+    app.kubernetes.io/instance: nodeexporter
+    app.kubernetes.io/version: "1.9.0"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-node-exporter
+      app.kubernetes.io/instance: nodeexporter
+  revisionHistoryLimit: 10
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        helm.sh/chart: prometheus-node-exporter-4.44.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: prometheus-node-exporter
+        app.kubernetes.io/name: prometheus-node-exporter
+        app.kubernetes.io/instance: nodeexporter
+        app.kubernetes.io/version: "1.9.0"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: nodeexporter-prometheus-node-exporter
+      containers:
+        - name: node-exporter
+          image: quay.io/prometheus/node-exporter:v1.9.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --path.udev.data=/host/root/run/udev/data
+            - --web.listen-address=[$(HOST_IP)]:{{ .Values.services.nodeExporter.metrics }}
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: HOST_IP
+              value: 0.0.0.0
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.services.nodeExporter.metrics }}
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+              path: /
+              port: {{ .Values.services.nodeExporter.metrics }}
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+              path: /
+              port: {{ .Values.services.nodeExporter.metrics }}
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly:  true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
+      hostNetwork: true
+      hostPID: true
+      hostIPC: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: root
+          hostPath:
+            path: /

--- a/sources/otel-lgtm-stack/v1.0.8/values.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/values.yaml
@@ -1,0 +1,246 @@
+# OpenTelemetry LGTM Stack Configuration
+# Phase 1: Essential Infrastructure Parameters
+
+# Cluster identification
+cluster:
+  name: "cluster-name"  # Update this to your actual cluster name
+
+# Namespace configuration
+namespace: otel-lgtm-stack
+
+# LGTM Stack storage configuration
+lgtm:
+  storage:
+    # Tempo storage for traces
+    tempo: 50Gi
+    # Loki storage for logs  
+    loki: 50Gi
+    # Grafana storage for dashboards/config  
+    grafana: 10Gi
+    # Mimir/Prometheus storage for metrics
+    mimir: 50Gi
+    # Loki additional storage
+    extra: 50Gi
+
+  # Config file overrides for the LGTM image (ghcr.io/silogen/docker-otel-lgtm).
+  # These full-file contents are mounted (via subPath) over the image's embedded
+  # configs at /otel-lgtm/<file>, so you can adjust Loki / OpenTelemetry Collector
+  # without rebuilding the image. The defaults below match the image's built-in
+  # configs, so out-of-the-box behavior is unchanged.
+  #
+  # NOTE: editing these requires a pod restart to take effect (subPath mounts do
+  # not hot-reload). The Deployment carries a checksum annotation so a helm
+  # upgrade with changed content triggers a rollout automatically.
+  #
+  # NOTE: otelcol-config-export-http.yaml is intentionally NOT overridable here,
+  # because run-otelcol.sh appends to it at runtime and a read-only mount would
+  # break that. Use env vars OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS
+  # for OTLP export configuration instead.
+  configOverrides:
+    # Full loki-config.yaml. Edit e.g. limits_config.retention_period to change
+    # Loki log retention.
+    lokiConfig: |
+      auth_enabled: false
+
+      server:
+        http_listen_port: 3100
+
+      common:
+        instance_addr: 127.0.0.1
+        path_prefix: /data/loki
+        storage:
+          filesystem:
+            chunks_directory: /data/loki/chunks
+            rules_directory: /data/loki/rules
+        replication_factor: 1
+        ring:
+          kvstore:
+            store: inmemory
+
+      schema_config:
+        configs:
+          - from: 2020-10-24
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: index_
+              period: 24h
+
+      ruler:
+        alertmanager_url: http://127.0.0.1:9093
+
+      pattern_ingester:
+        lifecycler:
+          min_ready_duration: 1s
+
+      ingester:
+        lifecycler:
+          min_ready_duration: 1s
+
+      frontend:
+        scheduler_dns_lookup_period: 1s
+        address: 127.0.0.1
+
+      query_scheduler:
+        use_scheduler_ring: false
+
+      limits_config:
+        retention_period: 168h  # 7 days (24h * 7)
+        otlp_config:
+          resource_attributes:
+            attributes_config:
+            - action: index_label
+              attributes:
+              - component.id
+              - workload.id
+              - log.type
+
+      compactor:
+        working_directory: /data/loki/compactor
+        compaction_interval: 10m
+        retention_enabled: true
+        retention_delete_delay: 2h
+        retention_delete_worker_count: 5  # TSDB: 1 file per day (~8 files for 7-day retention)
+        delete_request_store: filesystem  # Required by Loki v3.5.5+ when retention is enabled
+
+    # Full otelcol-config.yaml. Edit to adjust the OpenTelemetry Collector
+    # receivers / processors / exporters / pipelines.
+    otelcolConfig: |
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+              max_recv_msg_size_mib: 128
+            http:
+              endpoint: 0.0.0.0:4318
+              cors:
+                allowed_origins:
+                  - http://*
+        prometheus/collector:
+          config:
+            scrape_configs:
+              - job_name: "opentelemetry-collector"
+                scrape_interval: 1s
+                static_configs:
+                  - targets: ["127.0.0.1:8888"]
+
+      extensions:
+        health_check:
+          endpoint: 0.0.0.0:13133
+          path: "/ready"
+
+      processors:
+        batch:
+
+      exporters:
+        otlphttp/metrics:
+          endpoint: http://127.0.0.1:9090/api/v1/otlp
+          tls:
+            insecure: true
+        otlphttp/traces:
+          endpoint: http://127.0.0.1:4418
+          tls:
+            insecure: true
+        otlphttp/logs:
+          endpoint: http://127.0.0.1:3100/otlp
+          tls:
+            insecure: true
+        otlp/profiles:
+          endpoint: http://127.0.0.1:4040
+          tls:
+            insecure: true
+        debug/metrics:
+          verbosity: detailed
+        debug/traces:
+          verbosity: detailed
+        debug/logs:
+          verbosity: detailed
+
+      service:
+        extensions: [health_check]
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [batch]
+            exporters: [otlphttp/traces]
+            #exporters: [otlphttp/traces,debug/traces]
+          metrics:
+            receivers: [otlp, prometheus/collector]
+            processors: [batch]
+            exporters: [otlphttp/metrics]
+            #exporters: [otlphttp/metrics,debug/metrics]
+          logs:
+            receivers: [otlp]
+            processors: [batch]
+            exporters: [otlphttp/logs]
+            #exporters: [otlphttp/logs,debug/logs]
+          profiles:
+            receivers: [otlp]
+            exporters: [otlp/profiles]
+
+  # LGTM stack main deployment resources
+  resources:
+    limits:
+      memory: 8Gi
+    requests:
+      memory: 2Gi
+      cpu: '1'
+  
+# OpenTelemetry Collectors resource configuration  
+collectors:
+  resources:
+    # Metrics collector (deployment mode) - original values
+    metrics:
+      limits:
+        memory: 8Gi
+        cpu: '2'
+      requests:
+        memory: 1Gi
+        cpu: 500m
+    # Logs collector (daemonset mode) - original conservative values  
+    logs:
+      limits:
+        memory: 2Gi
+        cpu: '1'
+      requests:
+        memory: 400Mi  # Conservative default
+        cpu: 200m    # Conservative default
+
+# Service configuration
+services:
+  # Main LGTM stack service ports
+  lgtm:
+    grafana: 3000
+    otelGrpc: 4317
+    otelHttp: 4318
+    prometheus: 9090
+    loki: 3100
+  # Kube state metrics service port
+  kubeStateMetrics:
+    http: 8080
+  # Node exporter service port
+  nodeExporter:
+    metrics: 9100
+
+# Component enablement
+dashboards:
+  enabled: true
+  github:
+    enabled: true
+    folder: kubernetes
+    image: curlimages/curl:8.8.0
+    urls:
+      - https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-system-api-server.json
+      - https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-system-coredns.json
+      - https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-global.json
+      - https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-namespaces.json
+      - https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-nodes.json
+      - https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-pods.json
+
+nodeExporter:
+  enabled: true
+
+kubeStateMetrics:
+  enabled: true

--- a/sources/otel-lgtm-stack/v1.0.8/values.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/values.yaml
@@ -98,10 +98,10 @@ lgtm:
 
       compactor:
         working_directory: /data/loki/compactor
-        compaction_interval: 20m
+        compaction_interval: 30m
         retention_enabled: true
         retention_delete_delay: 2h
-        retention_delete_worker_count: 20
+        retention_delete_worker_count: 10 
         delete_request_store: filesystem  # Required by Loki v3.5.5+ when retention is enabled
 
     # Full otelcol-config.yaml. Edit to adjust the OpenTelemetry Collector

--- a/sources/otel-lgtm-stack/v1.0.8/values.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/values.yaml
@@ -98,10 +98,10 @@ lgtm:
 
       compactor:
         working_directory: /data/loki/compactor
-        compaction_interval: 10m
+        compaction_interval: 20m
         retention_enabled: true
         retention_delete_delay: 2h
-        retention_delete_worker_count: 5  # TSDB: 1 file per day (~8 files for 7-day retention)
+        retention_delete_worker_count: 20
         delete_request_store: filesystem  # Required by Loki v3.5.5+ when retention is enabled
 
     # Full otelcol-config.yaml. Edit to adjust the OpenTelemetry Collector

--- a/sources/otel-lgtm-stack/v1.0.8/values.yaml
+++ b/sources/otel-lgtm-stack/v1.0.8/values.yaml
@@ -32,6 +32,11 @@ lgtm:
   # not hot-reload). The Deployment carries a checksum annotation so a helm
   # upgrade with changed content triggers a rollout automatically.
   #
+  # NOTE: When overriding via cluster-org/cluster-values, you MUST copy the entire
+  # lokiConfig or otelcolConfig block—Helm does not deep-merge YAML strings, so
+  # partial overrides will discard the rest of the default config. Always start
+  # from the full block below and modify only the specific parameters you need.
+  #
   # NOTE: otelcol-config-export-http.yaml is intentionally NOT overridable here,
   # because run-otelcol.sh appends to it at runtime and a read-only mount would
   # break that. Use env vars OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS


### PR DESCRIPTION
## Overview
Upgrades LGTM stack from v1.0.7 to v1.0.8, migrating to the official Grafana image and introducing GitOps-managed configuration overrides.

## Key Changes

### 1. **Official Grafana Image Migration**
- **Before:** `ghcr.io/silogen/docker-otel-lgtm:v1.0.7` (our own custom)
- **After:** `grafana/otel-lgtm:0.29.2` [(official)](https://github.com/silogen/cluster-forge/blob/deb48d6e7b0347edef24c3967776b0428445ebd0/sources/otel-lgtm-stack/v1.0.8/templates/lgtm-stack.yaml#L326)

**Benefits:** Eliminates custom image maintenance, automatic upstream patches, latest components (Grafana 13.1, Loki 3.7.3, Prometheus 3.13.1), simplified upgrades.

### 2. **Configurable Loki & OtelCol**
ConfigMap-based overrides for production-ready settings:

**Loki:**
- 7-day retention with compaction [prevents unbounded growth](https://github.com/silogen/cluster-forge/blob/deb48d6e7b0347edef24c3967776b0428445ebd0/sources/otel-lgtm-stack/v1.0.8/values.yaml#L42)
- Balanced I/O: 30m compaction, 10 workers

### 3. **Kubernetes Improvements**
- **Faster deploys:** Probe delays 180s → 60s/120s (pod ready in ~60-75s)
- **Auto rollouts:** ConfigMap checksum triggers automatic pod restarts
- **Fixed health checks:** 6 actual services vs. 11 wrapper scripts

## Benefits
- **Cost control:** 7-day log retention vs. unlimited (automatically enforced)
- **Upgrades:** Change image tag, no rebuild

Validated on OCI VMs—all services operational, configs verified.