### PR TITLE
feat: extraApps for argo

### DIFF
--- a/docs/adding_extra_components.md
+++ b/docs/adding_extra_components.md
@@ -1,0 +1,185 @@
+# Adding Extra Components
+
+The core stack is defined by `root/values.yaml`'s `enabledApps`/`apps` and
+lives in this repo. Extra components — anything else a user wants installed
+alongside it — go through a separate app-of-apps, `cluster-forge-extras`, and
+never touch this repo.
+
+## Why separate
+
+Helm renders a chart all-or-nothing, so a malformed core `apps` entry would
+break every core Application. `root/templates/cluster-forge-extras.yaml`
+instead renders one static Application pointing at its own chart,
+`root-extras/`. A broken extra component only breaks `root-extras`'s render —
+core keeps reconciling.
+
+## Enabling a component
+
+Add an entry to `extraApps` in **`extra-apps-values.yaml`**, at the root of
+the cluster-values overlay repo (kept separate from `values.yaml` so it
+doesn't bloat as extras grow — path configurable via
+`externalValues.extraAppsPath`). No cluster-forge or cluster-bloom change
+needed:
+
+```yaml
+extraApps:
+  my-component:
+    project: default
+    source:
+      repoURL: https://github.com/some-org/some-chart.git
+      path: charts/some-chart          # or `chart: name` for a repo/OCI chart
+      targetRevision: v1.2.3
+      helm:
+        values: |
+          replicaCount: 1
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: my-component
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+```
+
+`extraApps.<name>` is a plain ArgoCD Application `spec:` block — `root-extras`
+renders it as-is (`root-extras/templates/cluster-extra-apps.yaml`), no schema
+of its own. Anything `Application.spec` supports (multi-source, Kustomize,
+sync waves, ignoreDifferences, ...) works; see the [ArgoCD
+docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/application.yaml).
+
+`extraApps` is a map so the overlay deep-merges into it — Helm replaces lists
+on merge but merges maps, which is also why core's `enabledApps` stays a list
+that `gitea-init-job` must always write out in full.
+
+## Upgrading an existing cluster
+
+On a fresh install there is nothing to do: `gitea-init-job` seeds an empty
+`extra-apps-values.yaml` into the cluster-values repo at bootstrap.
+
+Clusters upgrading into the first release that ships `cluster-forge-extras`
+predate that step, so the file will not exist. `cluster-forge-extras`
+references it unconditionally and Helm fails hard on a missing `-f` target, so
+create it in the cluster-values repo **before** bumping
+`clusterForge.targetRevision`:
+
+```yaml
+# extra-apps-values.yaml
+extraApps: {}
+```
+
+Bumping first is not harmful, just noisy: `cluster-forge-extras` sits in error
+(`failed to load value file`) and `cluster-forge` reports Degraded until the
+file lands. Nothing else is affected — core Applications keep reconciling, and
+the extras app recovers on its own once the file exists, with no manual sync.
+Note that migration runbooks gate on *all* apps being Synced/Healthy before
+proceeding, so it is worth avoiding the red window.
+
+## Shared context
+
+`cluster-forge-extras` forwards core's resolved values into `root-extras`, so
+extras see the same domain/registry/size as core:
+
+- `global.domain`, `global.clusterSize`
+- `ociRegistry.dockerHub`, `ociRegistry.ghcr`
+- `clusterForge.repoUrl`, `clusterForge.targetRevision`
+- `externalValues.repoUrl`, `externalValues.targetRevision` (your own
+  cluster-values overlay repo)
+
+Each `extraApps.<name>` block is passed through `tpl` in full, so any
+`{{ .Values... }}` reference resolves anywhere inside it:
+
+```yaml
+extraApps:
+  my-component:
+    project: default
+    source:
+      repoURL: "{{ .Values.ociRegistry.dockerHub }}"
+      chart: my-component-chart
+      targetRevision: "1.0.0"
+      helm:
+        values: |
+          ingress:
+            host: "my-component.{{ .Values.global.domain }}"
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: my-component
+    syncPolicy:
+      automated: { prune: true, selfHeal: true }
+```
+
+### Escaping templates meant for the downstream chart
+
+Because the whole block goes through `tpl`, `{{ ... }}` inside an inline
+`helm.values` string is evaluated *here*, not passed through to the chart you
+are installing. Anything using the downstream chart's own template variables —
+Alertmanager/Prometheus rules, Grafana dashboards, log formats — has to be
+escaped with backticks, or the render fails with `undefined variable`:
+
+```yaml
+        values: |
+          text: "Instance {{ `{{ $labels.instance }}` }} is down"
+```
+
+Worth knowing that a single unescaped entry breaks the render of `root-extras`
+as a whole, taking down *every* extra component, not just the offending one.
+Core is unaffected either way.
+
+### Quote version strings
+
+Helm parses the overlay before `root-extras` ever sees it, so an unquoted
+`targetRevision: 1.10` is read as the number `1.1` and silently installs the
+wrong chart version. `2.0` becomes `2`, which the ArgoCD CRD then rejects
+outright. Always quote:
+
+```yaml
+      targetRevision: "1.10"
+```
+
+## Using your own values file
+
+For config too large for an inline `helm.values` block, keep it in a file in
+the cluster-values overlay repo and add it as a second source via the
+forwarded `externalValues` repo:
+
+```yaml
+extraApps:
+  my-component:
+    project: default
+    sources:
+      - repoURL: https://github.com/some-org/some-chart.git
+        path: charts/some-chart
+        targetRevision: v1.2.3
+        helm:
+          valueFiles:
+            - $cluster-values/extra-apps/my-component/values.yaml
+      - repoURL: "{{ .Values.externalValues.repoUrl }}"
+        targetRevision: "{{ .Values.externalValues.targetRevision }}"
+        ref: cluster-values
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: my-component
+    syncPolicy:
+      automated: { prune: true, selfHeal: true }
+      syncOptions:
+        - CreateNamespace=true
+```
+
+Then create `extra-apps/my-component/values.yaml` yourself, next to
+`extra-apps-values.yaml` in the overlay repo.
+
+## Example
+
+`root-extras/values_addons.yaml` has copy-paste `extraApps` blocks (inline and
+values-file variants) with placeholder values — not real components. Copy
+one into your overlay's `extra-apps-values.yaml`, rename it, point
+`source`/`sources` at your own chart.
+
+## Verifying locally
+
+```bash
+helm template root-extras root-extras/ \
+  -f root-extras/values.yaml \
+  -f /path/to/your-overlay.yaml
+```

--- a/root-extras/Chart.yaml
+++ b/root-extras/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: root-extras
+description: ClusterForge Extras - renders user-provided extra ArgoCD Applications from the cluster-values overlay
+version: 0.1.0
+keywords:
+  - argocd
+  - infrastructure
+  - cluster-forge
+  - app-of-apps
+  - extras
+maintainers:
+  - name: ClusterForge Team
+home: https://github.com/silogen/cluster-forge
+sources:
+  - https://github.com/silogen/cluster-forge

--- a/root-extras/templates/_helpers.yaml
+++ b/root-extras/templates/_helpers.yaml
@@ -1,0 +1,16 @@
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+
+Duplicated from root/templates/_helpers.yaml by design: root-extras keeps its
+own copy so a malformed user-supplied extraApps entry can only break this
+chart's render, never the core stack's.
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/root-extras/templates/cluster-extra-apps.yaml
+++ b/root-extras/templates/cluster-extra-apps.yaml
@@ -1,0 +1,18 @@
+{{/*
+Each extraApps entry is the literal ArgoCD Application `spec:` block, exactly
+as it would be written by hand. No schema, no source-type detection: it is
+tpl-rendered as a whole (so any {{ .Values... }} reference resolves, including
+inside nested maps/lists) and wrapped with just enough metadata to make it an
+Application. See docs/adding_extra_components.md.
+*/}}
+{{- $root := . }}
+{{- range $name, $spec := .Values.extraApps }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ $name | quote }}
+  namespace: argocd
+spec:
+{{ include "common.tplvalues.render" ( dict "value" $spec "context" $root ) | indent 2 }}
+{{- end }}

--- a/root-extras/values.yaml
+++ b/root-extras/values.yaml
@@ -1,0 +1,26 @@
+# Shared context forwarded from the core cluster-forge Application
+# (root/templates/cluster-forge-extras.yaml). Defaults kept empty here so
+# `tpl` references resolve safely even before forwarding is wired up.
+global:
+  clusterSize:
+  domain:
+ociRegistry:
+  dockerHub:
+  ghcr:
+# The cluster-forge repo itself. Forwarded in case an extraApp's multi-source
+# spec wants to reference it directly.
+clusterForge:
+  repoUrl:
+  targetRevision:
+# The user's cluster-values overlay repo — same repo where extraApps entries
+# are written. Forwarded so an extraApp can reference a values file the user
+# created there (multi-source, see root-extras/values_addons.yaml).
+externalValues:
+  repoUrl:
+  targetRevision:
+
+# User-provided extra components, populated via the cluster-values overlay
+# repo. Each entry is the literal ArgoCD Application `spec:` block for that
+# component. See docs/adding_extra_components.md for the schema and
+# root-extras/values_addons.yaml for a ready-to-copy example.
+extraApps: {}

--- a/root-extras/values_addons.yaml
+++ b/root-extras/values_addons.yaml
@@ -1,0 +1,55 @@
+# Example add-on. NOT loaded automatically by any Application, and not a real
+# component — just a template to copy and adapt.
+#
+# extraApps.<name> is the literal ArgoCD Application `spec:` block, written
+# exactly as you'd write it by hand. Copy this block into the cluster-values
+# overlay repo's extra-apps-values.yaml, rename it, and point `source` at your
+# own chart/manifests (see docs/adding_extra_components.md).
+
+extraApps:
+  example-app:
+    project: default
+    source:
+      repoURL: https://example.com/some-org/some-chart.git
+      path: charts/example-app
+      targetRevision: v1.0.0
+      helm:
+        values: |
+          replicaCount: 1
+          ingress:
+            enabled: true
+            hostname: "example-app.{{ .Values.global.domain }}"
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: example-app
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+
+  # Same idea, but the chart values live in their own file that you create in
+  # THIS cluster-values overlay repo (e.g. extra-apps/example-app-2/values.yaml,
+  # next to this extra-apps-values.yaml) instead of an inline `helm.values`
+  # block. Add the overlay repo as a second source (forwarded as
+  # `externalValues`) and reference the file with the `$cluster-values` alias.
+  # example-app-2:
+  #   project: default
+  #   sources:
+  #     - repoURL: https://example.com/some-org/some-chart.git
+  #       path: charts/example-app
+  #       targetRevision: v1.0.0
+  #       helm:
+  #         valueFiles:
+  #           - $cluster-values/extra-apps/example-app-2/values.yaml
+  #     - repoURL: "{{ .Values.externalValues.repoUrl }}"
+  #       targetRevision: "{{ .Values.externalValues.targetRevision }}"
+  #       ref: cluster-values
+  #   destination:
+  #     server: https://kubernetes.default.svc
+  #     namespace: example-app-2
+  #   syncPolicy:
+  #     automated: { prune: true, selfHeal: true }
+  #     syncOptions:
+  #       - CreateNamespace=true

--- a/root/templates/cluster-forge-extras.yaml
+++ b/root/templates/cluster-forge-extras.yaml
@@ -1,0 +1,48 @@
+---
+{{- if and (not .Values.localHelmValues.enabled) .Values.externalValues.enabled }}
+# Renders a single, static child Application that owns the "extras" app-of-apps.
+# Unlike cluster-apps.yaml, this is NOT a loop over user-supplied entries: it is
+# the one thing core commits to, so a malformed extraApps entry in the
+# cluster-values overlay can only break the root-extras chart's own render,
+# never the core stack's Applications.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-forge-extras
+  namespace: argocd
+spec:
+  project: default
+  sources:
+  - repoURL: {{ .Values.clusterForge.repoUrl }}
+    targetRevision: {{ .Values.clusterForge.targetRevision | quote }}
+    path: root-extras
+    helm:
+      # Forwarded from core's already-resolved values, so extras use the SAME
+      # domain/registry/size as the core app-of-apps (single source of truth).
+      # Quoted so version-like scalars (2.0, 1.10) survive as strings.
+      values: |
+        global:
+          domain: {{ .Values.global.domain | quote }}
+          clusterSize: {{ .Values.global.clusterSize | quote }}
+        ociRegistry:
+          dockerHub: {{ .Values.ociRegistry.dockerHub | quote }}
+          ghcr: {{ .Values.ociRegistry.ghcr | quote }}
+        clusterForge:
+          repoUrl: {{ .Values.clusterForge.repoUrl | quote }}
+          targetRevision: {{ .Values.clusterForge.targetRevision | quote }}
+        externalValues:
+          repoUrl: {{ .Values.externalValues.repoUrl | quote }}
+          targetRevision: {{ .Values.externalValues.targetRevision | quote }}
+      valueFiles:
+        - $cluster-values/{{ .Values.externalValues.extraAppsPath }}
+  - repoURL: {{ .Values.externalValues.repoUrl }}
+    targetRevision: {{ .Values.externalValues.targetRevision | quote }}
+    ref: cluster-values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+{{- end }}

--- a/root/values.yaml
+++ b/root/values.yaml
@@ -4,6 +4,9 @@ clusterForge:
 externalValues:
   enabled: true
   path: values.yaml
+  # Dedicated file (in the same cluster-values overlay repo) for extraApps
+  # entries, kept separate from values.yaml so it doesn't bloat as extras grow.
+  extraAppsPath: extra-apps-values.yaml
   repoUrl: "http://gitea-http.cf-gitea.svc:3000/cluster-org/cluster-values.git"
   targetRevision: main
 global:

--- a/sources/gitea-init-job/0.1.0/templates/cf-init-gitea-cm.yaml
+++ b/sources/gitea-init-job/0.1.0/templates/cf-init-gitea-cm.yaml
@@ -401,6 +401,24 @@ data:
         "branch": "main"
       }' || echo "Failed to create values.yaml file"
 
+    echo "Step 8: Creating empty extra-apps-values.yaml in cluster-values repo..."
+
+    # cluster-forge-extras always references $cluster-values/extra-apps-values.yaml
+    # (see root/values.yaml's externalValues.extraAppsPath) - Helm's -f fails hard
+    # on a missing file, so this must exist even with no extraApps defined yet.
+    cat > /tmp/extra-apps-values.yaml << 'EOF'
+    extraApps: {}
+    EOF
+
+    curl -X POST "${GITEA_URL}/api/v1/repos/cluster-org/cluster-values/contents/extra-apps-values.yaml" \
+      -H "Authorization: token ${GITEA_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "message": "Initialize empty extra-apps-values.yaml",
+        "content": "'$(base64 -w 0 < /tmp/extra-apps-values.yaml)'",
+        "branch": "main"
+      }' || echo "Failed to create extra-apps-values.yaml file"
+
 
 
     echo "Setup completed successfully!"


### PR DESCRIPTION
Adds a pluggable "extra components" mechanism: a separate cluster-forge-extras app-of-apps (root-extras/ chart) lets users install arbitrary ArgoCD Applications via an extraApps map in their cluster-values overlay, without touching or forking the core cluster-forge stack.
Each extraApps.<name> entry is a raw ArgoCD Application spec: block, so any Application.spec feature is supported; entries live in a dedicated extra-apps-values.yaml file to keep them isolated from the main overlay values.yaml