### PR TITLE
ai-gateway: wire body-aware ext_authz on the default-deny SecurityPolicy

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -660,9 +660,13 @@ apps:
       - name: domain
         value: "{{ .Values.global.domain }}"
       - name: aiGateway.enabled
-        value: "true"  
+        value: "true"
       - name: aiGateway.routeHostname
         value: "ai.{{ .Values.global.domain }}"
+      # Point the body-aware extAuth backendRef + ReferenceGrant at wherever the
+      # ai-gateway-discovery app is declared, so they never drift from it.
+      - name: aiGateway.discoveryNamespace
+        value: "{{ .Values.apps.ai-gateway-discovery.namespace }}"
     namespace: envoy-gateway-system
     path: envoy-gateway-config
     syncWave: -15

--- a/root/values.yaml
+++ b/root/values.yaml
@@ -665,8 +665,9 @@ apps:
         value: "ai.{{ .Values.global.domain }}"
       # Point the body-aware extAuth backendRef + ReferenceGrant at wherever the
       # ai-gateway-discovery app is declared, so they never drift from it.
+      # index (not dot access) because the app key contains dashes.
       - name: aiGateway.discoveryNamespace
-        value: "{{ .Values.apps.ai-gateway-discovery.namespace }}"
+        value: '{{ index .Values.apps "ai-gateway-discovery" "namespace" }}'
     namespace: envoy-gateway-system
     path: envoy-gateway-config
     syncWave: -15

--- a/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-body-authz.yaml
+++ b/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-body-authz.yaml
@@ -1,12 +1,13 @@
 {{- if .Values.aiGateway.enabled }}
 # Cross-namespace grant for the body-aware ext_authz backendRef: the ai-gateway-default-deny
 # SecurityPolicy lives in envoy-gateway-system, but the ai-gateway-discovery ext_authz Service it
-# calls lives in ai-gateway-system. Gateway API requires a ReferenceGrant in the target namespace.
+# calls lives in the discovery app's namespace. Gateway API requires a ReferenceGrant in the
+# target (Service) namespace, which tracks .Values.aiGateway.discoveryNamespace.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: ai-gateway-body-authz-grant
-  namespace: ai-gateway-system  # ai-gateway-discovery Service namespace
+  namespace: {{ .Values.aiGateway.discoveryNamespace }}  # ai-gateway-discovery Service namespace
 spec:
   from:
     - group: gateway.envoyproxy.io

--- a/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-body-authz.yaml
+++ b/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-body-authz.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.aiGateway.enabled }}
+# Cross-namespace grant for the body-aware ext_authz backendRef: the ai-gateway-default-deny
+# SecurityPolicy lives in envoy-gateway-system, but the ai-gateway-discovery ext_authz Service it
+# calls lives in ai-gateway-system. Gateway API requires a ReferenceGrant in the target namespace.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: ai-gateway-body-authz-grant
+  namespace: ai-gateway-system  # ai-gateway-discovery Service namespace
+spec:
+  from:
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: envoy-gateway-system  # SecurityPolicy namespace
+  to:
+    - group: ""
+      kind: Service
+      name: ai-gateway-discovery  # ext_authz Service (discovery authz port)
+{{- end }}

--- a/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-body-authz.yaml
+++ b/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-body-authz.yaml
@@ -6,7 +6,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: ai-gateway-body-authz-grant
-  namespace: ai-gateway-discovery  # ai-gateway-discovery Service namespace
+  namespace: ai-gateway-system  # ai-gateway-discovery Service namespace
 spec:
   from:
     - group: gateway.envoyproxy.io

--- a/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-body-authz.yaml
+++ b/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-body-authz.yaml
@@ -6,7 +6,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: ai-gateway-body-authz-grant
-  namespace: ai-gateway-system  # ai-gateway-discovery Service namespace
+  namespace: ai-gateway-discovery  # ai-gateway-discovery Service namespace
 spec:
   from:
     - group: gateway.envoyproxy.io

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -11,6 +11,16 @@
 # Per-model apiKeyAuth SecurityPolicies from ai-gateway-discovery target individual HTTPRoutes;
 # a route-level SecurityPolicy overrides this gateway-level one for that route (Envoy Gateway
 # resolves by specificity, no merge), so keyed models authenticate and keyless ones hit deny.
+#
+# extAuth (body-aware, supplement): native per-model apiKeyAuth only enforces on the HEADER path
+# (x-ai-eg-model/backend). Standard OpenAI clients put the model in the JSON body with no routing
+# headers, so those requests fall through here. The extAuth block forwards the request body
+# (bodyToExtAuth) and Authorization to ai-gateway-discovery's ext_authz handler, which authorizes
+# per-model against the same bound-key Secrets and returns x-api-key-id for metrics. It is merged
+# into this one SecurityPolicy because Envoy Gateway allows only one gateway-scoped SP per Gateway;
+# on keyed HTTPRoutes the per-model route SP overrides this whole policy (extAuth included), so
+# extAuth only ever authorizes the header-less path — a supplement until upstream ai-gateway
+# supports body-path client auth natively.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
@@ -24,4 +34,19 @@ spec:
   authorization:
     # No rules → every request on ai-gateway not overridden by a route-level policy is denied.
     defaultAction: Deny
+  extAuth:
+    failOpen: false
+    bodyToExtAuth:
+      maxRequestBytes: 65536
+    headersToExtAuth:
+      - authorization
+    http:
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: ai-gateway-discovery
+          namespace: ai-gateway-system
+          port: 8083
+      headersToBackend:
+        - x-api-key-id
 {{- end }}

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -45,7 +45,7 @@ spec:
         - group: ''
           kind: Service
           name: ai-gateway-discovery
-          namespace: ai-gateway-discovery
+          namespace: ai-gateway-system
           port: 8083
       headersToBackend:
         - x-api-key-id

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -45,7 +45,7 @@ spec:
         - group: ''
           kind: Service
           name: ai-gateway-discovery
-          namespace: ai-gateway-system
+          namespace: ai-gateway-discovery
           port: 8083
       headersToBackend:
         - x-api-key-id

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -45,7 +45,9 @@ spec:
         - group: ''
           kind: Service
           name: ai-gateway-discovery
-          namespace: ai-gateway-system
+          # Tracks the ai-gateway-discovery app's namespace (root/values.yaml apps entry), so the
+          # backendRef follows wherever discovery deploys — no hardcoded namespace to drift.
+          namespace: {{ .Values.aiGateway.discoveryNamespace }}
           port: 8083
       headersToBackend:
         - x-api-key-id

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -27,6 +27,11 @@ gatewayDnsService:
 # populated (aim-keys-<workload-id> Secrets exist) — or keyed model traffic is denied.
 aiGateway:
   enabled: false
+  # Namespace where the ai-gateway-discovery Service (its ext_authz handler) runs. The body-aware
+  # extAuth backendRef + ReferenceGrant target this. Defaults to the canonical ai-gateway-system;
+  # root/values.yaml wires it to .Values.apps.ai-gateway-discovery.namespace so it always matches
+  # wherever the discovery app is actually declared (e.g. an env overlay pointing elsewhere).
+  discoveryNamespace: ai-gateway-system
   # SNI host the apps gateway passes through to ai-gateway. MUST equal the discovery
   # controller's controller.gateway.routeHostname (AIRouteHostname), e.g. gateway.<domain>.
   # Required when enabled — the ai-passthrough listener/route only render when set.


### PR DESCRIPTION
## Summary
- Merges an **`extAuth` block into the gateway-scoped `ai-gateway-default-deny` SecurityPolicy** so header-less inference requests (standard OpenAI clients, model in the body) are authorized by `ai-gateway-discovery`'s ext_authz handler. `bodyToExtAuth` forwards the body, `Authorization` is forwarded in, and `x-api-key-id` back out for metrics.
- Adds the cross-namespace **ReferenceGrant** allowing the SecurityPolicy (`envoy-gateway-system`) to reference the discovery Service (`ai-gateway-system`).
- **Why:** native per-model `apiKeyAuth` only enforces on the header path; a body-only request currently returns 200 with no/bogus key (verified live). See the paired core PR for the full root cause.

## Non-obvious decisions
- **Merged into the existing SP, not a new one:** Envoy Gateway allows only one gateway-scoped SecurityPolicy per Gateway (the repo's `security-policy-extauth.yaml` notes the same constraint). `authorization: Deny` is kept.
- On keyed HTTPRoutes the per-model route SecurityPolicy overrides this whole policy (extAuth included), so `extAuth` only ever authorizes the header-less path — a supplement until upstream ai-gateway supports body-path client auth.

## Test plan
- `helm template` / `helm lint` render the updated SecurityPolicy + ReferenceGrant correctly.
- End-to-end validated on app-dev via POC (same wiring): body-only no/bogus key → 401, valid → 200, valid key for a different model → 401, no-model → 403, header path unchanged.

## Base / dependencies / risk
- Targets **`bump_version_envoy_and_ai_gateway`** (the v1.8.1 + EAI-7304 default-deny world where the gap exists — not `main`, which still runs cluster-auth on the ai-gateway).
- Depends on the core PR (the discovery image/chart exposing the authz port on `:8083`). Republish the discovery `repoVersion` before this takes effect.
- Risk: **low-medium** — additive on the header path (unchanged); adds an ext_authz hop only on the header-less path. `failOpen: false` so the auth service being down denies rather than opens.