### PR TITLE
EAI-7243: forward x-ai-eg-backend for header-less metric attribution

### DIFF
--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -51,4 +51,9 @@ spec:
           port: 8083
       headersToBackend:
         - x-api-key-id
+        # Resolved backend (workload id) discovery authorized against — forwarded so the ext_proc
+        # stamps aim_service_id on the header-less path (the gateway can't resolve the backend
+        # from EDS endpoint metadata). Exact for single-backend models; approximate when several
+        # backends share a model name. See EAI-7243 metrics note.
+        - x-ai-eg-backend
 {{- end }}


### PR DESCRIPTION
## Summary
- Adds `x-ai-eg-backend` to the default-deny SecurityPolicy's `headersToBackend`.
- This lets the resolved backend that discovery forwards (**silogen/core#4309**) reach the ext_proc, which stamps `aim_service_id` on the **header-less/body path** — the label went empty when cluster-auth was removed (the gateway can't resolve the backend from EDS endpoint metadata for InferencePool/Service clusters).

## Merge order
- **Stacked on `bump_version_envoy_and_ai_gateway` (#794)** because the default-deny SP only exists on that branch; base is set to the bump branch for a clean one-line diff.
- **Retarget to `main` after #794 merges.**

## Notes
- Deploy order is independent of core#4309: if only one side ships the feature is simply inert (old discovery returns no header for this SP to forward; new discovery returns a header the old SP drops) — no breakage either way.
- No spoofing risk: a client that *sends* `x-ai-eg-backend` is on the header path (per-backend SP + native apiKeyAuth) and never hits this extAuth; `headersToBackend` only applies to discovery's response on the body path, where discovery is authoritative.

## Verification (live, app-dev)
Deployed alongside core#4309; header-less traffic (valid key, no routing headers) populated `aim_service_id` with the correct backend — keyed metric series grew on the populated series with no empty-backend series appearing.

## Risk
Low. Single additive header entry on one gateway-scoped SecurityPolicy.