### PR TITLE
Route /v1/models to ai-gateway-discovery for per-key filtering

### DIFF
--- a/sources/envoy-gateway-config/templates/httproute-ai-gateway-models.yaml
+++ b/sources/envoy-gateway-config/templates/httproute-ai-gateway-models.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.aiGateway.enabled .Values.aiGateway.routeHostname }}
+# Per-key /v1/models: route the OpenAI model-list call to ai-gateway-discovery's models handler
+# instead of Envoy AI Gateway's built-in aggregator, so the returned list is filtered to the
+# models the calling API key can actually use (deployed ∩ authorized) rather than the whole fleet.
+#
+# The exact-path match overrides the gateway's built-in /v1/models handling (a more-specific
+# HTTPRoute wins). The call is still authenticated by the gateway-scoped ai-gateway-default-deny
+# SecurityPolicy + body-aware ext_authz (which target the whole ai-gateway Gateway), so the handler
+# always sees a valid key. The backendRef is cross-namespace (Gateway here, discovery Service in
+# discoveryNamespace) — see reference-grant-ai-gateway-models.yaml.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ai-gateway-models
+  namespace: envoy-gateway-system  # same namespace as the ai-gateway Gateway
+spec:
+  hostnames:
+    - "{{ .Values.aiGateway.routeHostname }}"
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ai-gateway
+      namespace: envoy-gateway-system
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /v1/models
+          method: GET
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: ai-gateway-discovery
+          # discovery's per-key models handler port. Hardcoded like the ext_authz port (8083) in
+          # security-policy-ai-gateway-default-deny.yaml; must match the ai-gateway-discovery
+          # chart's controller.modelsPort.
+          namespace: {{ .Values.aiGateway.discoveryNamespace }}
+          port: 8082
+{{- end }}

--- a/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-models.yaml
+++ b/sources/envoy-gateway-config/templates/reference-grant-ai-gateway-models.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.aiGateway.enabled .Values.aiGateway.routeHostname }}
+# Cross-namespace grant for the /v1/models HTTPRoute backendRef: the ai-gateway-models HTTPRoute
+# lives in envoy-gateway-system (with the ai-gateway Gateway), but the ai-gateway-discovery Service
+# it routes to lives in the discovery app's namespace. Gateway API requires a ReferenceGrant in the
+# target (Service) namespace, which tracks .Values.aiGateway.discoveryNamespace — mirrors
+# reference-grant-ai-gateway-body-authz.yaml, but from an HTTPRoute instead of a SecurityPolicy.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: ai-gateway-models-grant
+  namespace: {{ .Values.aiGateway.discoveryNamespace }}  # ai-gateway-discovery Service namespace
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: envoy-gateway-system  # HTTPRoute namespace
+  to:
+    - group: ""
+      kind: Service
+      name: ai-gateway-discovery  # per-key models handler Service (discovery models port)
+{{- end }}

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-models.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-models.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.aiGateway.enabled .Values.aiGateway.routeHostname }}
+# Route-scoped SecurityPolicy for the /v1/models HTTPRoute.
+#
+# The gateway-scoped ai-gateway-default-deny SecurityPolicy applies BOTH extAuth and
+# authorization.defaultAction: Deny to every route on the ai-gateway Gateway. Per-model inference
+# routes escape the deny because ai-gateway-discovery stamps a per-model apiKeyAuth SecurityPolicy
+# that overrides it. The static /v1/models HTTPRoute has no such per-model policy, so without this
+# it authenticates via extAuth but is then refused by the gateway-level RBAC deny (HTTP 403).
+#
+# This route-scoped policy overrides the gateway-level one for /v1/models (Envoy Gateway resolves
+# by specificity, no merge): it keeps extAuth — so a missing/invalid key is still rejected at the
+# gateway (401) and a valid bound key is forwarded with x-api-key-id — but carries NO authorization
+# block, so RBAC no longer denies. The request then reaches the models handler, which returns the
+# list filtered to the caller's key. The extAuth backendRef reuses the cross-namespace grant from
+# reference-grant-ai-gateway-body-authz.yaml (SecurityPolicy → ai-gateway-discovery Service).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: ai-gateway-models
+  namespace: envoy-gateway-system  # must match the ai-gateway Gateway / HTTPRoute namespace
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ai-gateway-models
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - authorization
+    http:
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: ai-gateway-discovery
+          namespace: {{ .Values.aiGateway.discoveryNamespace }}
+          port: 8083
+      headersToBackend:
+        - x-api-key-id
+{{- end }}


### PR DESCRIPTION
## Summary
- Adds an exact-path `GET /v1/models` HTTPRoute on the `ai-gateway` Gateway that routes the OpenAI model-list call to `ai-gateway-discovery`'s new per-key models handler (Service `:8082`), plus the cross-namespace ReferenceGrant for that backendRef.
- A more-specific HTTPRoute overrides Envoy AI Gateway's built-in `/v1/models` aggregator, so the caller gets a list scoped to the models their key can use instead of the whole fleet.

**Why:** the built-in `/v1/models` returns every declared model to any valid key. The companion `ai-gateway-discovery` change serves a per-key list; this routes the endpoint to it.

**Non-obvious decisions:**
- The call stays authenticated by the existing gateway-scoped `ai-gateway-default-deny` SecurityPolicy + body-aware ext_authz (which target the whole `ai-gateway` Gateway) — no new auth wiring needed; the handler always sees a valid key.
- Both manifests render only under `aiGateway.enabled` + `routeHostname`, so they ship and retract atomically with the rest of the AI gateway.
- Port `8082` is hardcoded (like the ext_authz `8083` in the default-deny SP) and must match the discovery chart's `controller.modelsPort`.

## Base branch
Targets \`bump_version_envoy_and_ai_gateway\` — the AI-gateway templates (\`ai-gateway\` Gateway, default-deny SP) live on that line, not main.

## Risk
Low. Gated behind \`aiGateway.enabled\`; no change to existing routes/policies.

## Test plan
- \`helm template\` renders both manifests as valid YAML when enabled + routeHostname set, and renders nothing when gated off.
- Deferred to a live cluster: confirm the exact-path \`/v1/models\` HTTPRoute (backendRef) actually overrides the extproc's built-in ImmediateResponse and proxies to the discovery Service; then the live auth matrix.

## Dependencies
- Requires the companion core PR (silogen/core#4322) that adds the \`/v1/models\` handler + \`modelsPort\` to the discovery chart. Deploy together.
- Related: EAI-226, EAI-6835.