### PR TITLE
EAI-7854 Pin aiwb-infra-cnpg to one instance on small profile

### DIFF
--- a/root/values_small.yaml
+++ b/root/values_small.yaml
@@ -60,6 +60,9 @@ enabledApps:
   - rabbitmq
 
 apps:
+  aiwb-infra-cnpg:
+    valuesObject:
+      instances: 1
   argocd:
     valuesObject:
       applicationSet:


### PR DESCRIPTION
Related:
* https://github.com/silogen/cluster-forge/pull/798

The `small` profile did not override `instances` for `aiwb-infra-cnpg`, so the
chart default (multiple replicas) was used on single-node clusters where the
extra CNPG replicas cannot be scheduled.

Set `instances: 1`, matching what `root/values_medium.yaml` already does.

## Testing

Renders on the small profile with a single CNPG instance for `aiwb-infra-cnpg`.