### PR TITLE
EAI-7854 Spread CNPG instances across distinct nodes

### DIFF
--- a/sources/eai-infra/airm-cnpg/0.1.0/templates/cnpg-cluster.yaml
+++ b/sources/eai-infra/airm-cnpg/0.1.0/templates/cnpg-cluster.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   affinity:
     enablePodAntiAffinity: true
-    topologyKey: topology.kubernetes.io/zone
+    podAntiAffinityType: {{ .Values.podAntiAffinityType | quote }}
+    topologyKey: {{ .Values.topologyKey | quote }}
   bootstrap:
     initdb:
       database: {{ .Values.database }}

--- a/sources/eai-infra/airm-cnpg/0.1.0/values.yaml
+++ b/sources/eai-infra/airm-cnpg/0.1.0/values.yaml
@@ -7,6 +7,12 @@ database: "airm"
 username: "airm_user"
 image: "ghcr.io/cloudnative-pg/postgresql:17.2"
 instances: 1
+# Spread instances across distinct nodes. "preferred" schedules them apart when
+# nodes allow it and falls back to co-scheduling otherwise, so a cluster with
+# fewer nodes than instances still comes up. Set "required" to make the spread
+# binding, which leaves surplus instances Pending until nodes are added.
+podAntiAffinityType: "preferred"
+topologyKey: "kubernetes.io/hostname"
 userSecretName: "airm-cnpg-user"
 superuserSecretName: "airm-cnpg-superuser"
 sharedBuffers: "256MB"

--- a/sources/eai-infra/aiwb-cnpg/0.1.0/templates/cnpg-cluster.yaml
+++ b/sources/eai-infra/aiwb-cnpg/0.1.0/templates/cnpg-cluster.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   affinity:
     enablePodAntiAffinity: true
-    topologyKey: topology.kubernetes.io/zone
+    podAntiAffinityType: {{ .Values.podAntiAffinityType | quote }}
+    topologyKey: {{ .Values.topologyKey | quote }}
   bootstrap:
     initdb:
       database: {{ .Values.database }}

--- a/sources/eai-infra/aiwb-cnpg/0.1.0/values.yaml
+++ b/sources/eai-infra/aiwb-cnpg/0.1.0/values.yaml
@@ -7,6 +7,12 @@ database: "aiwb"
 username: "aiwb_user"
 image: "ghcr.io/cloudnative-pg/postgresql:17.2"
 instances: 3
+# Spread instances across distinct nodes. "preferred" schedules them apart when
+# nodes allow it and falls back to co-scheduling otherwise, so a cluster with
+# fewer nodes than instances still comes up. Set "required" to make the spread
+# binding, which leaves surplus instances Pending until nodes are added.
+podAntiAffinityType: "preferred"
+topologyKey: "kubernetes.io/hostname"
 userSecretName: "aiwb-cnpg-user"
 superuserSecretName: "aiwb-cnpg-superuser"
 sharedBuffers: "256MB"

--- a/sources/keycloak-config/templates/keycloak-cluster.yaml
+++ b/sources/keycloak-config/templates/keycloak-cluster.yaml
@@ -66,7 +66,8 @@ metadata:
 spec:
   affinity:
     enablePodAntiAffinity: true
-    topologyKey: topology.kubernetes.io/zone
+    podAntiAffinityType: {{ .Values.cnpg.podAntiAffinityType | quote }}
+    topologyKey: {{ .Values.cnpg.topologyKey | quote }}
   bootstrap:
     initdb:
       database: keycloak

--- a/sources/keycloak-config/values.yaml
+++ b/sources/keycloak-config/values.yaml
@@ -9,3 +9,9 @@ cnpg:
   # so node maintenance stalls until someone disables it by hand.
   # Set true or false to override.
   enablePDB: null
+  # Spread instances across distinct nodes. "preferred" schedules them apart
+  # when nodes allow it and falls back to co-scheduling otherwise, so a cluster
+  # with fewer nodes than instances still comes up. Set "required" to make the
+  # spread binding, which leaves surplus instances Pending until nodes exist.
+  podAntiAffinityType: "preferred"
+  topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
Related:
* https://github.com/silogen/core/pull/4334

**Draft, and deliberately so.** The `sources/eai-infra/{aiwb,airm}-cnpg`
copies here are mirrors of charts that live in `silogen/core`. What ArgoCD
actually deploys is the published OCI chart pinned at `repoVersion: 2.0.0` in
`root/values.yaml`, not these directories, so the deployed clusters only pick
this fix up after core/#4334 merges, a core release is cut and promoted to
`amdenterpriseai`, and `repoVersion` is bumped here.

This PR is the placeholder holding the cluster-forge side of the change until
then.

## TODO: Before merging
- [ ] core/#4334 merged
- [ ] Core release cut and charts promoted to `amdenterpriseai`
- [ ] `repoVersion` bumped for the core-published entries in [root/values.yaml](https://github.com/silogen/cluster-forge/blob/d4b64c3f315063e02f5dc7cae52825aba19903ed/root/values.yaml#L85-L87) ,
       with the matching `sbom/components.yaml` update
- [ ] Confirm the mirrors still match core's charts at that tag, including the 
      pre-existing `managed.roles` divergence these copies carry
- [ ] Mark ready for review

## Problem

Three CNPG clusters in this repo hardcode anti-affinity on
`topology.kubernetes.io/zone`:

```yaml
affinity:
  enablePodAntiAffinity: true
  topologyKey: topology.kubernetes.io/zone
```

Most of our clusters are single-zone, and many nodes carry no zone label at
all. A topology key with one value across the cluster spreads nothing, so
instances co-schedule onto a single node. Losing that node takes down every
replica at once, and draining it evicts them together.

This is the caveat left open by the `enablePDB` work in #798: a PDB only means
something if the replicas it protects actually sit on different nodes.

## Change

Spread on `kubernetes.io/hostname`, which every node has, and expose both knobs
as values instead of hardcoding them:

| Value                 | Default                  |
| --------------------- | ------------------------ |
| `podAntiAffinityType` | `preferred`              |
| `topologyKey`         | `kubernetes.io/hostname` |

`preferred` keeps single-node and small clusters working: instances land on
separate nodes where nodes allow it and co-schedule where they do not, so
nothing sits `Pending`. Set `required` to make the spread binding.

Files touched:

- `sources/eai-infra/aiwb-cnpg/0.1.0` and `sources/eai-infra/airm-cnpg/0.1.0`,
  mirroring core/#4334. Consumed only by `docs/manual_helm_install`.
- `sources/keycloak-config`, which lives in this repo and is not mirrored.
  It runs `instances: 1`, so this is a no-op today and matters only if that
  count is ever raised. Included so all three CNPG clusters stay consistent
  rather than leaving one on a key that does not spread.

## Testing

- `helm lint` clean on both `eai-infra` charts
- All three render the expected affinity block, and the `eai-infra` pair render
  correctly with `--set podAntiAffinityType=required`
- `helm template ./root` passes on all four profiles (`values`, `values_small`,
  `values_medium`, `values_large`), matching the `helm-chart-checks` matrix

Note: `helm template sources/keycloak-config` fails on a pre-existing YAML
parse error in `keycloak-realm-templates-cm.yaml`, unrelated to this change and
reproducible on `main`. The cluster template was verified by rendering with
that file excluded.

