### PR TITLE
EAI-7889 Add pod anti-affinity for SeaweedFS and fix keycloak-old CNPG topology

### DIFF
--- a/root/values_large.yaml
+++ b/root/values_large.yaml
@@ -53,6 +53,13 @@ enabledApps:
   - rabbitmq
   
 apps:
+  airm-infra-cnpg:
+    valuesObject:
+      instances: 2
+  keycloak:
+    valuesObject:
+      cnpg:
+        instances: 2
   seaweedfs-config:
     valuesObject:
       seaweed:

--- a/sources/keycloak-old/templates/keycloak-cnpg.yaml
+++ b/sources/keycloak-old/templates/keycloak-cnpg.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   affinity:
     enablePodAntiAffinity: true
-    topologyKey: topology.kubernetes.io/zone
+    podAntiAffinityType: {{ .Values.cnpg.podAntiAffinityType | quote }}
+    topologyKey: {{ .Values.cnpg.topologyKey | quote }}
   bootstrap:
     initdb:
       database: {{ .Values.postgresql.database }}

--- a/sources/keycloak-old/values.yaml
+++ b/sources/keycloak-old/values.yaml
@@ -14,6 +14,8 @@ cnpg:
   # so node maintenance stalls until someone disables it by hand.
   # Set true or false to override.
   enablePDB: null
+  podAntiAffinityType: "preferred"
+  topologyKey: "kubernetes.io/hostname"
   storage:
     storageClassName: "default"
 

--- a/sources/seaweedfs-config/templates/seaweedfs-seaweed.yaml
+++ b/sources/seaweedfs-config/templates/seaweedfs-seaweed.yaml
@@ -13,6 +13,18 @@ spec:
       enabled: false
     replicas: {{ .master.replicas }}
     volumeSizeLimitMB: 1024
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - master
+              topologyKey: {{ $.Values.seaweed.affinity.topologyKey }}
   volume:
     ingress:
       enabled: false
@@ -23,8 +35,32 @@ spec:
     # Topology configuration for rack/datacenter-aware placement
     rack: "rack1"
     dataCenter: "dc1"
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - volume
+              topologyKey: {{ $.Values.seaweed.affinity.topologyKey }}
   filer:
     replicas: {{ .filer.replicas }}
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - filer
+              topologyKey: {{ $.Values.seaweed.affinity.topologyKey }}
     volumes:
       - name: s3-metadata
         persistentVolumeClaim:

--- a/sources/seaweedfs-config/values.yaml
+++ b/sources/seaweedfs-config/values.yaml
@@ -1,6 +1,8 @@
 domain: # to be filled by cluster-forge app
 seaweed:
   storageClassName: mlstorage
+  affinity:
+    topologyKey: "kubernetes.io/hostname"
   master:
     replicas: 1
     volumeSizeLimitMB: 1024


### PR DESCRIPTION
Related:
* https://github.com/silogen/cluster-forge/pull/802
* https://github.com/silogen/cluster-forge/pull/801
* https://amd.atlassian.net/browse/EAI-7889

Companion to #802 (CNPG topology fix) and #801 (small profile pin). This PR
covers the remaining anti-affinity work from EAI-7889 that those PRs do not
address.

## Problem

**SeaweedFS** — master, volume, and filer have zero anti-affinity. In large
clusters (3 master replicas, 3 volume replicas) all pods can land on one node.
Losing that node takes down the entire S3 storage layer.

**keycloak-old CNPG** — #802 fixed `keycloak-config` but the active Keycloak
chart is `keycloak-old` (`root/values.yaml` maps `keycloak` to
`path: keycloak-old`). The `keycloak-old` CNPG cluster still hardcodes
`topology.kubernetes.io/zone`, which is a no-op on bare-metal.

**Large profile CNPG instance counts** — AIRM and Keycloak CNPG run 1 instance
even on large clusters (6+ nodes). A single database instance means no
automatic failover; losing the node requires pod rescheduling and WAL recovery.

## Change

### SeaweedFS anti-affinity

Add `preferredDuringSchedulingIgnoredDuringExecution` pod anti-affinity for
master, volume, and filer components in the Seaweed CR template. Topology key
is configurable via `seaweed.affinity.topologyKey` (default
`kubernetes.io/hostname`).

| Component | Large replicas | Anti-affinity |
| --------- | -------------- | ------------- |
| master    | 3              | soft, weight 100 |
| volume    | 3              | soft, weight 100 |
| filer     | 1              | soft, weight 100 (future-proofing) |

Soft anti-affinity ensures single-node and medium clusters still schedule all
pods without anything sitting `Pending`.

### keycloak-old CNPG topology fix

Same pattern as #802 — expose `podAntiAffinityType` and `topologyKey` as
values, defaulting to `preferred` and `kubernetes.io/hostname`. Consistent with
the AIRM and AIWB CNPG charts from #802.

### Large profile instance counts

| App | Before | After | Reason |
| --- | ------ | ----- | ------ |
| AIRM CNPG | 1 | 2 | Primary + hot standby for automatic failover |
| Keycloak CNPG | 1 | 2 | Auth DB failover in seconds instead of minutes |

AIWB CNPG already has 3 instances — no change needed.

Files touched:

- `sources/seaweedfs-config/templates/seaweedfs-seaweed.yaml` — anti-affinity blocks
- `sources/seaweedfs-config/values.yaml` — affinity defaults
- `sources/keycloak-old/templates/keycloak-cnpg.yaml` — templatize topology
- `sources/keycloak-old/values.yaml` — topology defaults
- `root/values_large.yaml` — AIRM and Keycloak CNPG instances: 2

## Testing

- [ ] Deploy on single-node ephemeral VM (medium profile) — verify no scheduling failures
- [ ] Deploy on multi-node cluster (3+ CP nodes) — verify SeaweedFS and CNPG pods spread across nodes
- [ ] `helm template ./root` on all four profiles