### PR TITLE
EAI-7854 Repair YAML block scalar in keycloak realm ConfigMap

### DIFF
--- a/sources/keycloak-config/templates/keycloak-realm-templates-cm.yaml
+++ b/sources/keycloak-config/templates/keycloak-realm-templates-cm.yaml
@@ -2121,8 +2121,7 @@ data:
             }
           }
         ],
-        "org.keycloak.keys.KeyProvider": [
-]
+        "org.keycloak.keys.KeyProvider": []
       },
       "internationalizationEnabled": false,
       "supportedLocales": [],


### PR DESCRIPTION
## Problem

`helm template sources/keycloak-config` fails on `main`:

```
Error: YAML parse error on keycloak-config/templates/keycloak-realm-templates-cm.yaml:
error converting YAML to JSON: yaml: line 2123: did not find expected key
```

## Root cause

The whole file is a single YAML block scalar (`airm-realm.json: |`) whose
content is indented by 4 spaces. Commit 0608a006 ("397 remove realm secrets",
#441) emptied the `org.keycloak.keys.KeyProvider` array but left its closing
bracket at column 0:

```yaml
        "org.keycloak.keys.KeyProvider": [
]
```

A column-0 line terminates the block scalar, so the parser stops treating the
rest of the JSON as scalar content and reads `]` as a new mapping key.

## Fix

Indent the bracket onto the same line. Emptying the array was intentional in
0608a006, only the indentation was wrong.

## Verification

* `helm template sources/keycloak-config` renders cleanly.
* Embedded JSON parses: `.realm == "airm"`, `KeyProvider` array length 0.
* `jq -S` diff of the intended JSON payload before vs after is **identical**,
  so no realm configuration changes.
* Templated every chart under `sources/` that has a `Chart.yaml`. No other
  chart has this breakage.
