### PR TITLE
EAI-5958: Stamp workload_id on per-pod CPU/memory metrics

### DIFF
--- a/sources/otel-lgtm-stack/v1.0.7/templates/collectors-logs-metrics-k8s.yaml
+++ b/sources/otel-lgtm-stack/v1.0.7/templates/collectors-logs-metrics-k8s.yaml
@@ -723,3 +723,111 @@ spec:
           receivers: [prometheus]
           processors: [memory_limiter, batch, attributes]
           exporters: [otlp]
+---
+# Per-pod CPU / memory metrics enriched with workload_id.
+# cAdvisor metrics scraped by otel-collector-metrics-k8s are node-scoped, so their
+# pod/namespace arrive as datapoint labels and cannot be associated to a pod by the
+# k8sattributes processor (which works at the resource level). This daemonset uses the
+# kubeletstats receiver, which emits pod/container-scoped metrics with k8s.pod.* as
+# resource attributes, so k8sattributes can look up the pod and stamp its
+# airm.silogen.ai/workload-id label. A transform then copies the identity resource
+# attributes down to datapoint attributes so they survive OTLP ingestion as series
+# labels (workload_id, project_id, pod, namespace, container) — matching how GPU and
+# vLLM metrics already carry workload_id for per-workload observability.
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-collector-metrics-kubelet
+  namespace: {{ .Release.Namespace }}
+spec:
+  mode: daemonset
+  serviceAccount: otel-collector
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.113.0"
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8888"
+  resources:
+    limits:
+      cpu: {{ .Values.collectors.resources.logs.limits.cpu | quote }}
+      memory: {{ .Values.collectors.resources.logs.limits.memory }}
+    requests:
+      cpu: {{ .Values.collectors.resources.logs.requests.cpu | quote }}
+      memory: {{ .Values.collectors.resources.logs.requests.memory }}
+  config:
+    receivers:
+      kubeletstats:
+        collection_interval: 30s
+        auth_type: serviceAccount
+        endpoint: "https://${env:K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
+        metric_groups:
+          - pod
+          - container
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      batch:
+        send_batch_size: 2000
+        timeout: 10s
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          labels:
+          - from: pod
+            key: airm.silogen.ai/workload-id
+            tag_name: workload.id
+          - from: pod
+            key: airm.silogen.ai/project-id
+            tag_name: project.id
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.container.name
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+      # Copy identity resource attributes down to datapoint attributes so they are
+      # emitted as Prometheus series labels (resource attributes otherwise land in
+      # target_info, not on the series itself).
+      transform/workload-id-labels:
+        error_mode: ignore
+        metric_statements:
+          - context: datapoint
+            statements:
+              - set(attributes["workload_id"], resource.attributes["workload.id"]) where resource.attributes["workload.id"] != nil
+              - set(attributes["project_id"], resource.attributes["project.id"]) where resource.attributes["project.id"] != nil
+              - set(attributes["namespace"], resource.attributes["k8s.namespace.name"]) where resource.attributes["k8s.namespace.name"] != nil
+              - set(attributes["pod"], resource.attributes["k8s.pod.name"]) where resource.attributes["k8s.pod.name"] != nil
+              - set(attributes["container"], resource.attributes["k8s.container.name"]) where resource.attributes["k8s.container.name"] != nil
+      attributes:
+        actions:
+          - key: k8s_cluster_name
+            action: insert
+            value: {{ .Values.cluster.name | quote }}
+    exporters:
+      otlp:
+        endpoint: http://lgtm-stack.otel-lgtm-stack.svc.cluster.local:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics:
+          receivers: [kubeletstats]
+          processors: [memory_limiter, batch, k8sattributes, transform/workload-id-labels, attributes]
+          exporters: [otlp]


### PR DESCRIPTION
## Summary
- Adds a dedicated `kubeletstats` daemonset collector (`otel-collector-metrics-kubelet`) to the `otel-lgtm-stack` chart that emits **per-pod CPU and memory** metrics labeled with **`workload_id`** (plus `project_id`, `pod`, `namespace`, `container`).
- Enables per-workload CPU/system-memory observability for EPYC (CPU-only) AIMs in the AIWB dashboard, scoped the same stable way GPU/VRAM metrics already are.

## Why
EPYC-based AIMs (parent initiative EAI-2244) hold model weights in RAM, so the AIWB dashboard needs CPU + system-memory panels alongside the existing GPU/VRAM panels. The AIWB metrics backend scopes every panel by a `workload_id="<AIM-uuid>"` label. GPU metrics carry that label (stamped by the device-metrics-exporter); vLLM metrics carry it (vLLM collector relabel). **Container CPU/memory metrics do not.**

## Root cause of the gap
`otel-collector-metrics-k8s` scrapes cAdvisor via a `role: node` scrape (`/metrics/cadvisor`). Those metrics are **node-scoped**, so `pod`/`namespace` arrive as *datapoint* labels. The `k8sattributes` processor associates pods at the **resource** level, so it cannot enrich node-scoped cAdvisor series — leaving `container_cpu_usage_seconds_total` / `container_memory_working_set_bytes` without `workload_id`.

## Approach
Use the `kubeletstats` receiver instead, which emits **pod/container-scoped** metrics with `k8s.pod.*` as resource attributes:
1. `kubeletstats` (daemonset, per-node kubelet at `:10250`) → pod + container metric groups.
2. `k8sattributes` looks up the pod and extracts `airm.silogen.ai/workload-id` → `workload.id` (and `project-id`).
3. `transform/workload-id-labels` copies the identity resource attributes **down to datapoint attributes**, so they survive OTLP→Mimir ingestion as **series labels** (resource attributes otherwise land in `target_info`, not on the series).

Reuses the existing `otel-collector` ServiceAccount — RBAC already grants `nodes/stats`, `nodes/proxy`, `pods`, `namespaces`, so no RBAC change is needed.

## Risk
Low–medium. Additive: a new collector; existing pipelines are untouched. New series (`k8s_pod_cpu_*`, `k8s_pod_memory_*`, `k8s_container_*`) with per-pod cardinality (comparable to existing cAdvisor series). Uses the same collector image and OTLP endpoint as the other collectors.

## Test plan / validation status
- **Config review** against the deployed v1.0.7 collectors and the working `k8sattributes`/`workload-id` pattern already used by the logs collector and the vLLM collector.
- **Runtime validation deferred** — app-dev is currently unreachable and the local kind cluster is degraded (host inotify limit exhausted → kube-proxy/CoreDNS/OTel-operator crashlooping, so the operator webhook can't admit the new collector). Kept as **draft** until validated on a live cluster.
- On deploy, verify: `k8s_pod_cpu_usage{workload_id="<aim-uuid>"}` and `k8s_pod_memory_working_set_bytes{workload_id="<aim-uuid>"}` return series for a labeled workload pod, and that `workload_id`/`namespace`/`pod` appear as labels.

## Follow-ups (separate work, not in this PR)
- AIWB backend: add `MetricName` entries + PromQL builders for CPU usage / CPU availability / system memory.
- AIWB frontend: CPU/memory panels + accelerator-type gating.
- CPU/memory **availability** denominator sourced from the K8s object (resolved-profile requests/limits) rather than kube-state-metrics.