### PR TITLE
ai-gateway: raise drainTimeout so model-deploy churn doesn't kill live completions

### DIFF
--- a/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
+++ b/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
@@ -21,9 +21,16 @@ spec:
   # always finishes before force-close. A drained chain is released as soon as its connections close
   # (or at drainTimeout), so cost is bounded by concurrent long streams, not by churn rate. This does
   # not reduce churn — it stops churn from cutting live streams (the filter-topology fix is upstream:
-  # envoyproxy/ai-gateway filter dedup + rule naming). NOTE: pod-termination drains are still bounded
-  # by terminationGracePeriodSeconds (EG default 360s), so rollovers can still cut streams >6m — a
-  # separate concern from the on-running-pod churn this addresses.
+  # envoyproxy/ai-gateway filter dedup + rule naming).
+  #
+  # DECOUPLED FROM POD TERMINATION. Envoy Gateway derives terminationGracePeriodSeconds =
+  # drainTimeout + 5m (internal/infrastructure/kubernetes/proxy/resource_provider.go), so a naive 31m
+  # would make every pod *termination* (rollout, node drain, autoscaler scale-down, upgrade) block up
+  # to 36m — and hit that ceiling on every rollout via the lingering-Prometheus-scrape drain bug
+  # (envoyproxy/gateway#4125). The envoyDeployment.patch below forces terminationGracePeriodSeconds
+  # back to the 360s default, so shutdown stays fast (rollovers still cut streams >6m, unchanged) while
+  # the running-pod churn drain keeps the full 31m. The two timers are independent at runtime: 31m is
+  # --drain-time-s (LDS drain on a live pod); 360s is the k8s SIGKILL deadline on termination.
   shutdown:
     drainTimeout: 31m
   # Run the sanitize-backend-header Lua (envoy-extension-policy-backend-sanitize.yaml) before
@@ -47,6 +54,18 @@ spec:
           nodeSelector:
             cluster-bloom/first-node: "true"
           priorityClassName: "system-cluster-critical"
+        # Override EG's derived terminationGracePeriodSeconds (= drainTimeout + 5m) back to the 360s
+        # default, decoupling the long running-pod churn drain (shutdown.drainTimeout, above) from pod
+        # termination so rollouts / node drains / autoscaling are not held up to ~36m. Applied last in
+        # EG's render, so it wins over the computed value; verify on deploy that the Deployment shows
+        # terminationGracePeriodSeconds: 360.
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  terminationGracePeriodSeconds: 360
   telemetry:
     accessLog:
       settings:

--- a/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
+++ b/sources/envoy-gateway-config/templates/ai-gateway-proxy-config.yaml
@@ -9,6 +9,23 @@ metadata:
   name: ai-gateway-proxy-config
   namespace: envoy-gateway-system
 spec:
+  # Keep long LLM completions alive across listener churn. Every model deploy/undeploy changes the
+  # ai-gateway filter set (per-model EPP ext_proc + catch-all ext_authz filters), which triggers an
+  # Envoy in-place filter-chain update: the superseded chain is drained and any connection still on
+  # it is force-closed at the end of the drain window. With the 60s default that severs in-flight
+  # streaming completions mid-body (measured: unrelated-model events killing held ai.<domain>
+  # streams). Envoy Gateway feeds shutdown.drainTimeout into Envoy's --drain-time-s, which governs
+  # LDS-triggered filter-chain draining on a *running* pod — so raising it lets a superseded chain
+  # hold its connections long enough for the completion to finish and close naturally. Set >= the
+  # ai-gateway-discovery REQUEST_TIMEOUT (default 30m); a completion cannot outlive that, so it
+  # always finishes before force-close. A drained chain is released as soon as its connections close
+  # (or at drainTimeout), so cost is bounded by concurrent long streams, not by churn rate. This does
+  # not reduce churn — it stops churn from cutting live streams (the filter-topology fix is upstream:
+  # envoyproxy/ai-gateway filter dedup + rule naming). NOTE: pod-termination drains are still bounded
+  # by terminationGracePeriodSeconds (EG default 360s), so rollovers can still cut streams >6m — a
+  # separate concern from the on-running-pod churn this addresses.
+  shutdown:
+    drainTimeout: 31m
   # Run the sanitize-backend-header Lua (envoy-extension-policy-backend-sanitize.yaml) before
   # native apiKeyAuth AND before the ai-gateway ext_proc, so a bogus x-ai-eg-backend is stripped
   # before the ext_proc snapshots request headers for the aim_service_id metric label (EAI-7864).


### PR DESCRIPTION
## Summary
Stops long LLM completions on the **ai-gateway** from being cut mid-stream when the listener churns on model deploy/undeploy — without slowing pod termination.

## Problem
Every model deploy/undeploy changes the ai-gateway filter set (per-model EPP `ext_proc` + catch-all `ext_authz` filters). That triggers an Envoy **in-place filter-chain update**: the superseded chain is drained and any connection still on it is force-closed at the end of the drain window. With the 60s default, an in-flight streaming completion is severed mid-body — measured on app-dev: an *unrelated* model's event killed a held `ai.<domain>` stream ~60s later (`CURLE_PARTIAL_FILE`). It lands entirely on the longest-running requests, so it's invisible in ordinary testing.

## Change
Raise `EnvoyProxy.shutdown.drainTimeout` to `31m` on the ai-gateway EnvoyProxy. Envoy Gateway feeds `drainTimeout` into Envoy's `--drain-time-s`, which governs LDS-triggered filter-chain draining on a **running** pod, so a churn-superseded chain now holds its connections long enough for the completion to finish and close naturally (≥ the ai-gateway-discovery `REQUEST_TIMEOUT` of 30m). A drained chain is released as soon as its connections close, so cost is bounded by concurrent long streams, not by churn rate.

### Decoupled from pod termination (important)
EG derives `terminationGracePeriodSeconds = drainTimeout + 5m`, so a bare `31m` would make every pod **termination** (rollout, node drain, autoscaler scale-down, upgrade) block up to **36m** — and hit that ceiling on every rollout via the lingering-Prometheus-scrape drain bug ([envoyproxy/gateway#4125](https://github.com/envoyproxy/gateway/issues/4125)). To avoid that, `envoyDeployment.patch` forces `terminationGracePeriodSeconds` back to the **360s** default. The two timers are independent at runtime:
- `31m` → `--drain-time-s`: the running-pod LDS churn drain (protects in-flight streams).
- `360s` → the k8s SIGKILL deadline on termination (rollouts/node drains stay at today's 6m).

## Scope / blast radius
- **ai-gateway only** (Gateway-scoped EnvoyProxy; the GatewayClass has no cluster-wide EnvoyProxy). The shared `https` gateway and everything else are untouched.
- Does **not** reduce churn — it stops churn from cutting live streams. The real filter-topology fix is upstream (envoyproxy/ai-gateway EPP filter dedup + generated-rule naming; `#1917`).
- Rollovers still cut streams older than 6m (unchanged status quo).

## Test plan
- `helm template … --set aiGateway.enabled=true` renders `drainTimeout: 31m` + the `terminationGracePeriodSeconds: 360` patch; `helm lint` clean.
- **On deploy, verify the patch stuck** (we override an EG-managed field):
  ```
  kubectl get deploy -n envoy-gateway-system <ai-gateway-deploy> \
    -o jsonpath='{.spec.template.spec.terminationGracePeriodSeconds}'   # expect 360, not 2160
  ```
- **Churn check:** hold a >60s stream on `ai.<domain>`, deploy/undeploy another model, confirm the stream is not dropped and `total_filter_chains_draining` (not `total_listeners_draining`) moved.
