### PR TITLE
EAI-8229 Fix CLUSTER_SIZE small: keep global.domain, hooks, drop gitea

### DIFF
--- a/root/templates/cluster-forge.yaml
+++ b/root/templates/cluster-forge.yaml
@@ -31,10 +31,29 @@ spec:
     targetRevision: {{ .Values.clusterForge.targetRevision }}
     path: root
     helm:
-      {{- if .Values.clusterForge.targetRevision }}
+      # Every value bloom passed with --set when it first rendered this file
+      # must be repeated here. ArgoCD renders this same chart again to manage
+      # the app-of-apps, and that render sees only the valueFiles below, so a
+      # value that is not a parameter is lost on the first sync and the root
+      # app overwrites its own spec without it. global.domain went missing
+      # this way: envoy-gateway-config then wrote a CoreDNS rewrite of
+      # `.*\.` and every name in the cluster resolved to the gateway.
+      # externalValues.enabled carries these in cluster-values/values.yaml
+      # instead, which is why only the small path was affected.
+      {{- if or .Values.clusterForge.targetRevision .Values.global.domain .Values.global.clusterSize }}
       parameters:
+        {{- if .Values.clusterForge.targetRevision }}
         - name: clusterForge.targetRevision
           value: {{ .Values.clusterForge.targetRevision | quote }}
+        {{- end }}
+        {{- if .Values.global.domain }}
+        - name: global.domain
+          value: {{ .Values.global.domain | quote }}
+        {{- end }}
+        {{- if .Values.global.clusterSize }}
+        - name: global.clusterSize
+          value: {{ .Values.global.clusterSize | quote }}
+        {{- end }}
       {{- end }}
       valueFiles:
         - {{ .Values.clusterForge.valuesFile }}

--- a/root/values_small.yaml
+++ b/root/values_small.yaml
@@ -31,8 +31,6 @@ enabledApps:
   - envoy-gateway-config
   - envoy-ai-gateway-crds
   - envoy-ai-gateway
-  - gitea
-  - gitea-config
   - kaiwo
   - kaiwo-config
   - kaiwo-crds

--- a/sources/envoy-gateway/v1.8.1/templates/certgen-rbac.yaml
+++ b/sources/envoy-gateway/v1.8.1/templates/certgen-rbac.yaml
@@ -10,6 +10,12 @@ metadata:
   {{- end }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    # ArgoCD deletes a hook that has no delete policy before it makes the
+    # hook again, and it does that on each resume of the operation. The
+    # certgen job needs more time than the interval between two resumes,
+    # so the job never started and envoy-gateway stayed at PreSync. Keep
+    # the hook until it succeeds.
+    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
   {{- if .Values.certgen.rbac.annotations }}
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
@@ -27,6 +33,12 @@ metadata:
   {{- end }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    # ArgoCD deletes a hook that has no delete policy before it makes the
+    # hook again, and it does that on each resume of the operation. The
+    # certgen job needs more time than the interval between two resumes,
+    # so the job never started and envoy-gateway stayed at PreSync. Keep
+    # the hook until it succeeds.
+    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
   {{- if .Values.certgen.rbac.annotations }}
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
@@ -53,6 +65,12 @@ metadata:
   {{- end }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    # ArgoCD deletes a hook that has no delete policy before it makes the
+    # hook again, and it does that on each resume of the operation. The
+    # certgen job needs more time than the interval between two resumes,
+    # so the job never started and envoy-gateway stayed at PreSync. Keep
+    # the hook until it succeeds.
+    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
   {{- if .Values.certgen.rbac.annotations }}
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
@@ -78,6 +96,12 @@ metadata:
   {{- end }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    # ArgoCD deletes a hook that has no delete policy before it makes the
+    # hook again, and it does that on each resume of the operation. The
+    # certgen job needs more time than the interval between two resumes,
+    # so the job never started and envoy-gateway stayed at PreSync. Keep
+    # the hook until it succeeds.
+    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
   {{- if .Values.certgen.rbac.annotations }}
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}
@@ -112,6 +136,12 @@ metadata:
   {{- end }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    # ArgoCD deletes a hook that has no delete policy before it makes the
+    # hook again, and it does that on each resume of the operation. The
+    # certgen job needs more time than the interval between two resumes,
+    # so the job never started and envoy-gateway stayed at PreSync. Keep
+    # the hook until it succeeds.
+    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
   {{- if .Values.certgen.rbac.annotations }}
     {{- toYaml .Values.certgen.rbac.annotations | nindent 4 -}}

--- a/sources/envoy-gateway/v1.8.1/templates/certgen.yaml
+++ b/sources/envoy-gateway/v1.8.1/templates/certgen.yaml
@@ -7,6 +7,12 @@ metadata:
   {{- include "eg.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    # ArgoCD deletes a hook that has no delete policy before it makes the
+    # hook again, and it does that on each resume of the operation. The
+    # certgen job needs more time than the interval between two resumes,
+    # so the job never started and envoy-gateway stayed at PreSync. Keep
+    # the hook until it succeeds.
+    "helm.sh/hook-delete-policy": hook-succeeded
   {{- if .Values.certgen.job.annotations }}
     {{- toYaml .Values.certgen.job.annotations | nindent 4 -}}
   {{- end }}

--- a/sources/envoy-gateway/v1.8.1/templates/envoy-proxy-topology-injector-webhook.yaml
+++ b/sources/envoy-gateway/v1.8.1/templates/envoy-proxy-topology-injector-webhook.yaml
@@ -20,6 +20,12 @@ metadata:
   name: 'envoy-gateway-topology-injector.{{ include "eg.namespace" . }}'
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
+    # ArgoCD deletes a hook that has no delete policy before it makes the
+    # hook again, and it does that on each resume of the operation. The
+    # certgen job needs more time than the interval between two resumes,
+    # so the job never started and envoy-gateway stayed at PreSync. Keep
+    # the hook until it succeeds.
+    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "-1"
   {{- if .Values.topologyInjector.annotations }}
     {{- toYaml .Values.topologyInjector.annotations | nindent 4 -}}


### PR DESCRIPTION
Fixes [EAI-8229](https://amd.atlassian.net/browse/EAI-8229).

`CLUSTER_SIZE: small` does not give a platform that works. Three faults stop
it, one after the other. This pull request corrects all three.

| # | Fault | Correction |
|---|---|---|
| 1 | The root application loses `global.domain`, and CoreDNS then sends every name to the gateway | Keep the value as a parameter |
| 2 | `envoy-gateway` never leaves PreSync, so the Gateway API CRDs are never installed | Give the hooks a delete policy |
| 3 | `gitea` waits for a secret that nothing makes on this path | Do not enable it on the small path |

Only the small path is affected. With `externalValues.enabled`, the values of
fault 1 come from `cluster-values/values.yaml` in the in-cluster Gitea.

---

## 1. The root application loses global.domain

The root Application is rendered two times. bloom renders it with
`helm template ... --set global.domain=...` and applies the result. ArgoCD then
renders the same chart again to manage the app-of-apps, and that render reads
only the value files.

`root/templates/cluster-forge.yaml` copied `clusterForge.targetRevision` into
`spec.source.helm.parameters`, but not `global.domain` and not
`global.clusterSize`. The second render saw them empty, and the root
application overwrote its own specification without them.

An empty domain made `envoy-gateway-config` write

```
rewrite continue name regex .*\. https.envoy-gateway-system.svc.cluster.local answer auto
```

`.*\.` matches every name:

```
argocd-repo-server.argocd.svc.cluster.local   -> 10.243.148.243
argocd-redis.argocd.svc.cluster.local         -> 10.243.148.243
nope-does-not-exist.default.svc.cluster.local -> 10.243.148.243
```

`10.243.148.243` is the `envoy-gateway-system/https` service. The ArgoCD
controller could not reach its repo-server, and all 39 applications stayed in
`ComparisonError`.

An empty `global.clusterSize` also removed `values_small.yaml` from the value
files, so the cluster got the wrong set of applications. The count decreased
from 39 to 26.

**Correction.** Copy both values into the parameters, in the same way as
`clusterForge.targetRevision`. The render now gives the same result each time:

```
helm template cluster-forge root --show-only templates/cluster-forge.yaml \
  --values root/values.yaml --values root/values_small.yaml \
  --set global.domain=1.2.3.4.nip.io | grep -A1 global.domain
```

## 2. envoy-gateway never leaves PreSync

```
waiting for completion of hook /ServiceAccount/envoy-gateway-gateway-helm-certgen and 5 more hooks
```

The hooks in `sources/envoy-gateway/v1.8.1` carried `helm.sh/hook` but no
`helm.sh/hook-delete-policy`. ArgoCD reads a missing policy as
`BeforeHookCreation`, so it deletes each hook before it makes the hook again,
and it does that each time it resumes the operation. The operation resumes
about every four seconds, and the certgen job needs more time than that, so
the job never started.

Measured: the operation was `Running` for 30 minutes, and
`envoy-gateway-system` held no service account, no job and no pod. The Gateway
API CRDs were never installed, so each application that uses a `Gateway`, an
`HTTPRoute` or a `TLSRoute` failed with

```
failed to discover server resources for group version gateway.networking.k8s.io/v1
```

Ten applications stayed `OutOfSync/Missing`, among them `envoy-gateway-config`,
`keycloak`, `gitea-config`, `openbao-config` and `seaweedfs-config`.

**Correction.** `hook-delete-policy: hook-succeeded` on the seven hooks of that
chart. The hooks now stay until the job completes.

## 3. gitea cannot start on the small path

bloom does not bootstrap gitea when `CLUSTER_SIZE` is small.
`clusterforge_setup.yaml` holds `when: (CLUSTER_SIZE | default('medium')) !=
'small'`, and `bootstrap_gitea.yaml` is the only thing that makes the secret
`gitea-admin-credentials`. `values_small.yaml` enabled the `gitea` and
`gitea-config` applications all the same.

Measured: `secret "gitea-admin-credentials" not found`, 255 restarts in 59
minutes, and the application stayed `Degraded`.

**Correction.** Do not enable the two applications on the small path. That path
reads the repository from GitHub, because `externalValues.enabled` is false and
`clusterForge.repoUrl` names GitHub, so it has no use for the in-cluster Gitea.
Nothing else in `values_small.yaml` names it.

---

## Test

One Kaytoo VM, Ubuntu 24.04, no GPU, `CLUSTER_SIZE: small`,
`DOMAIN: <ip>.nip.io`, `CERT_OPTION: generate`. Installed with bloom, then
cluster-forge from this branch.

| | Before | After |
|---|---|---|
| root app parameters | `clusterForge.targetRevision` only | + `global.domain`, `global.clusterSize` |
| root app valueFiles | `values.yaml` | `values.yaml`, `values_small.yaml` |
| applications | 26 | 53 |
| `ComparisonError` | 39 of 39 | 0 |
| not `Synced+Healthy` | 39 | 1 |

Name resolution now goes both ways, as intended:

```
regex .*\.129.213.21.55.nip.io

argocd-repo-server.argocd.svc.cluster.local  -> 10.243.9.71      (the service)
kc.129.213.21.55.nip.io                      -> 10.243.209.223   (the gateway)
```

envoy-gateway installs and both gateways are programmed:

```
phase: Succeeded, message: successfully synced (all tasks run)
pod/envoy-gateway-5f775fc774-tl7bs   1/1   Running

ai-gateway   envoy-gateway   10.243.109.13   True
https        envoy-gateway   10.0.255.153    True
```

## What stays open

One application, `envoy-gateway-config`, is still `OutOfSync`, and it is not
corrected here. `security-policy-ai-gateway-default-deny.yaml` asks for port
8083 on `ai-gateway-system/ai-gateway-discovery`, and envoy-gateway refuses the
policy:

```
ExtAuth: TCP Port 8083 not found on service ai-gateway-system/ai-gateway-discovery
```

`ai-gateway-discovery-chart:2.0.0` gives one port, `health:8081`, and the
container gives only `health:8081`, so there is no ext-auth port. This is a
mismatch of versions and not a wrong number, and port 8081 is the health probe,
so no correction is guessed here.
[EAI-8231](https://amd.atlassian.net/browse/EAI-8231) records it.


[EAI-8229]: https://amd.atlassian.net/browse/EAI-8229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EAI-8231]: https://amd.atlassian.net/browse/EAI-8231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ