### PR TITLE
Renew AIWB OpenBao token instead of rotating it

### DIFF
--- a/sources/openbao-config/0.1.0/templates/openbao-secret-manager-cm.yaml
+++ b/sources/openbao-config/0.1.0/templates/openbao-secret-manager-cm.yaml
@@ -127,9 +127,14 @@ data:
 
     # AIWB scoped API-key write credential (EAI-7277). Unlike cluster-auth (which reuses the
     # root token), AIWB gets a token scoped to secrets/apikeys/* so it cannot write elsewhere.
-    # No renewal machinery: re-mint only when the stored token is absent or no longer valid.
+    # Minted periodic and renewed on every run, so the stored value stays constant: AIWB reads
+    # OPENBAO_TOKEN once at startup (env var, snapshotted at pod start), so a rotation strands the
+    # running pod on a revoked token and every API-key create 403s until it is restarted. Re-mint
+    # remains the fallback for a token that is absent or can no longer be renewed.
     # Capabilities match the AIWB OpenBao client — data create/read/update, metadata
-    # create/update (delete_version_after / native expiry) and delete (revocation).
+    # create/update (delete_version_after / native expiry) and delete (revocation), plus
+    # renew-self so the token can extend its own lease (`bao token renew` with no argument
+    # calls auth/token/renew-self; there is no `renew-self` subcommand in the OpenBao CLI).
     echo "Ensuring apikeys-write-policy..."
     if ! echo '
     path "secrets/data/apikeys/*" {
@@ -140,6 +145,9 @@ data:
     }
     path "auth/token/lookup-self" {
       capabilities = ["read"]
+    }
+    path "auth/token/renew-self" {
+      capabilities = ["update"]
     }' | bao policy write apikeys-write-policy -; then
       echo "ERROR: Failed to write apikeys-write-policy"
       failed=$((failed + 1))
@@ -156,7 +164,15 @@ data:
       200)
         if stored=$(bao kv get -field=value secrets/aiwb-openbao-token 2>/dev/null); then
           if BAO_TOKEN="$stored" bao token lookup >/dev/null 2>&1; then
-            echo "SKIP: secrets/aiwb-openbao-token (scoped token still valid)"
+            # Periodic tokens renew indefinitely, so renewing here keeps the stored value stable
+            # rather than letting it lapse and forcing a rotation consumers cannot see.
+            # A pre-existing non-periodic token is capped by max_ttl and will eventually fail to
+            # renew; it is then re-minted below as periodic, a one-time rotation.
+            if BAO_TOKEN="$stored" bao token renew >/dev/null 2>&1; then
+              echo "SKIP: secrets/aiwb-openbao-token (scoped token renewed)"
+            else
+              echo "SKIP: secrets/aiwb-openbao-token (valid but not renewable; re-mint at expiry)"
+            fi
           else
             need_mint=true
             old_token="$stored"
@@ -174,7 +190,7 @@ data:
 
     if [ "$need_mint" = "true" ]; then
       echo "MINT: secrets/aiwb-openbao-token (scoped apikeys-write token)"
-      if new_token=$(bao token create -policy=apikeys-write-policy -ttl=768h -orphan -field=token); then
+      if new_token=$(bao token create -policy=apikeys-write-policy -period=768h -orphan -field=token); then
         if [ -n "$old_token" ]; then
           cas_version=$(bao kv get -format=json secrets/aiwb-openbao-token 2>/dev/null | jq -r '.data.metadata.version') || cas_version=""
         else


### PR DESCRIPTION
## Summary

- Mint the AIWB scoped OpenBao token **periodic** (`-period=768h` instead of `-ttl=768h`) and renew it on every secret-manager run, so the stored token value stays constant instead of rotating.
- Grant `auth/token/renew-self` in `apikeys-write-policy`, matching what `read-policy` already grants the external-secrets identity.
- Re-mint remains the fallback when the token is absent or no longer renewable. That path also migrates the existing non-periodic token at its next expiry.

**Why:** creating an API key in AI Workbench returns 500. Observed on app-dev.

**Root cause:** `aiwb-api` reads `OPENBAO_TOKEN` from the environment once at import (`app/openbao/config.py`) and builds its OpenBao client at startup, so the value is snapshotted when the pod starts. The scoped token was minted with a 32-day TTL; on expiry the secret-manager re-mints and revokes the old one. ESO updates the Secret, but the running pod keeps presenting the revoked token, so every write to `secrets/data/apikeys/*` returns 403, surfacing as a 500 from the create endpoint. It stays broken until someone restarts the deployment. Nothing was misconfigured; this is missing lifecycle handling around a credential that was deliberately scoped rather than reusing the root token (EAI-7277).

**Why periodic rather than just renewing:** a non-periodic token cannot be renewed past the system max TTL, so adding renewal alone would not have prevented the expiry. Verified against the running OpenBao: a periodic token reports `period 768h` / `explicit_max_ttl 0s` and renewal resets its lease, while `-ttl=768h` produces no `period` and stays capped from creation.

**Note on the CLI:** there is no `bao token renew-self` subcommand. `bao token renew` with no argument calls `auth/token/renew-self`, which is what the policy grant covers.

**Risk:** low. Confined to the secret-manager script. The policy addition mirrors an existing grant, and the mint change only affects tokens created from here on.

## Impact

One rotation is still pending. The token currently deployed is non-periodic and expires 2026-09-23. Even with this merged it will fail renewal then, be re-minted as periodic, and strand `aiwb-api` once more. Either accept a restart around that date, or force the rotation at a controlled time and restart the pod.

## Non-goals

This does not stop a **manual** re-mint from stranding the pod, because the token is still read once at startup. The durable fix is for AIWB to authenticate rather than hold a token, the way external-secrets already does via userpass against `read-policy`. Worth a separate ticket.

## Test plan

- Secret-manager logs `SKIP: secrets/aiwb-openbao-token (scoped token renewed)` instead of `(scoped token still valid)`.
- `bao token lookup` on the stored token reports `period 768h`.
- Creating an API key in AI Workbench succeeds past the token's original expiry without restarting `aiwb-api`.