### PR TITLE
Declare the defaulted backendRef weight on ai-gateway-default-deny

### DIFF
--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -49,6 +49,10 @@ spec:
           # backendRef follows wherever discovery deploys — no hardcoded namespace to drift.
           namespace: {{ .Values.aiGateway.discoveryNamespace }}
           port: 8083
+          # Envoy Gateway defaults weight to 1 on every backendRef. Set it explicitly so the
+          # manifest matches the live object, otherwise ArgoCD reports this policy (and the
+          # envoy-gateway-config Application) permanently OutOfSync.
+          weight: 1
       headersToBackend:
         - x-api-key-id
         # Resolved backend (workload id) discovery authorized against — forwarded so the ext_proc


### PR DESCRIPTION
## Summary

The ext_authz `backendRef` on the `ai-gateway-default-deny` SecurityPolicy does not declare `weight`, but Envoy Gateway defaults it to `1`. ArgoCD owns `spec.extAuth.http` under server-side apply, so the defaulted field lands inside its own field ownership and shows up as a diff it can never reconcile. The SecurityPolicy, and with it the whole `envoy-gateway-config` Application, reports OutOfSync permanently while staying Healthy.

Declaring `weight: 1` makes the manifest match what Envoy Gateway already applies.

**Why:** reported by Petrus as consistently reproducible on freshly deployed clusters from main.

**No behaviour change.** `weight: 1` is the value already in effect. The older `cluster-auth-extauth-policy` has declared `weight` on its backendRef since it was written; this newer policy, added in #794, did not.

## Verification (app-dev, `targetRevision: main`, Envoy Gateway v1.8.1)

It is the only OutOfSync resource in the Application:

```
app: OutOfSync / Healthy
  OUT  SecurityPolicy  ai-gateway-default-deny      OutOfSync
       SecurityPolicy  cluster-auth-extauth-policy  Synced
       ReferenceGrant  ai-gateway-body-authz-grant  Synced
       ...all other 15 resources Synced
```

Field ownership confirms the mechanism:

```
managedFields: manager=argocd-controller op=Apply
               spec.extAuth subfields: [bodyToExtAuth, failOpen, headersToExtAuth, http]
```

`http` is ArgoCD-owned, so the defaulted `weight` beneath it counts against its diff. On `cluster-auth-extauth-policy` ArgoCD owns only `extAuth.grpc`, which is why that policy's own defaulted `failOpen` is ignored and it stays Synced. That asymmetry is why this fix is scoped to one policy.

A server-side dry-run of the fixed manifest, applied as `argocd-controller` against app-dev, produces the live object exactly:

```
kubectl apply --server-side --dry-run=server --field-manager=argocd-controller
diff <dry-run spec> <live spec>  ->  no differences
```

So the diff clears once this lands.

## Scope

Does **not** address the separate ai-gateway-discovery port issue from the same discussion. This policy references the discovery ext_authz handler on port 8083, which first exists in discovery chart 2.0.2; the published chart is 2.0.1 and cluster-forge pins 2.0.0. Header-less inference stays broken until 2.0.2 is cut, promoted, and pinned. Expect the Application to go green while that is still outstanding.

Also unconfirmed: whether the OutOfSync resource on the reporter's fresh clusters is this same one. This is a proven bug on main either way, but the link is worth checking with:

```bash
kubectl get application envoy-gateway-config -n argocd \
  -o jsonpath='{range .status.resources[?(@.status!="Synced")]}{.kind}/{.name}{"\n"}{end}'
```

## Test plan

After merge, `envoy-gateway-config` on app-dev should report Synced with no other resource changing:

```bash
kubectl -n argocd get application envoy-gateway-config -o jsonpath='{.status.sync.status}'
```
