### PR TITLE
EAI-8232: Merge main to release v2.4.x (SeaweedFS External Secret PreSync removal)

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -840,6 +840,14 @@ apps:
     syncWave: -1
   seaweedfs-config:
     ignoreDifferences:
+      - group: external-secrets.io
+        kind: ExternalSecret
+        jqPathExpressions:
+          # The CRD defaults these inside spec.data[]; Argo's predicted live
+          # state drops them, so the app never converges without this.
+          - .spec.data[].remoteRef.conversionStrategy
+          - .spec.data[].remoteRef.decodingStrategy
+          - .spec.data[].remoteRef.metadataPolicy
       - group: gateway.networking.k8s.io
         kind: HTTPRoute
         jqPathExpressions:

--- a/sources/seaweedfs-config/templates/seaweedfs-es-admin.yaml
+++ b/sources/seaweedfs-config/templates/seaweedfs-es-admin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: seaweed-admin-es-secret
   namespace: seaweedfs-instance
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    # Not a PreSync hook: Argo does not track hooks, so selfHeal cannot restore them.
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   secretStoreRef:

--- a/sources/seaweedfs-config/templates/seaweedfs-es-s3-config.yaml
+++ b/sources/seaweedfs-config/templates/seaweedfs-es-s3-config.yaml
@@ -4,9 +4,7 @@ metadata:
   name: seaweedfs-es-s3-config
   namespace: seaweedfs-instance
   annotations:
-    # PreSync + sync-wave: ensure OpenBao-backed Secret exists (and Argo marks this
-    # resource Healthy per ExternalSecret health rules) before the Seaweed CR syncs.
-    argocd.argoproj.io/hook: PreSync
+    # Not a PreSync hook: Argo does not track hooks, so selfHeal cannot restore them.
     argocd.argoproj.io/sync-wave: "-2"
 spec:
   secretStoreRef:


### PR DESCRIPTION
Merges `main` into `release/v2.4.x`. Contains the EAI-8232 work (PR #821).

## Changes

**`sources/seaweedfs-config/templates/seaweedfs-es-admin.yaml`, `seaweedfs-es-s3-config.yaml`**
- Removed `argocd.argoproj.io/hook: PreSync` from both ExternalSecrets. Argo does not track hook resources, so selfHeal cannot restore them if they are deleted or drift.
- `sync-wave` annotations retained (`-1` and `-2`) so ordering relative to the Seaweed CR is preserved.

**`root/values.yaml`**
- Added `ignoreDifferences` for `external-secrets.io/ExternalSecret` under `apps.seaweedfs-config`, covering `.spec.data[].remoteRef.conversionStrategy`, `.decodingStrategy`, and `.metadataPolicy`. The CRD defaults these fields inside `spec.data[]` and Argo's predicted live state drops them, so without this the app never converges once the resources are tracked instead of being hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)