### PR TITLE
feat(EAI-8292): webhook heal script and platform gates (complements #824)

### DIFF
--- a/.github/workflows/helm-chart-checks.yaml
+++ b/.github/workflows/helm-chart-checks.yaml
@@ -29,6 +29,20 @@ jobs:
       - name: Helm template
         run: helm template ./root -f ${{ matrix.values }}
 
+  install-script-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4.3.0
+
+      - name: Run install helper tests
+        run: |
+          chmod +x scripts/ai-gateway-webhook-health.sh scripts/platform-gates/*.sh scripts/test/run-tests.sh
+          scripts/test/run-tests.sh
+
   kyverno-policies:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Comprehensive documentation is available in the `/docs` folder:
 | Topic | Documentation |
 |-------|---------------|
 | **Getting Started** | [On-Premises Installation Guide](https://enterprise-ai.docs.amd.com/en/latest/platform-infrastructure/on-premises-installation.html) |
-| **Configuration** | [Cluster Size Configuration](docs/cluster_size_configuration.md) |
+| **Configuration** | [Cluster Size Configuration](docs/cluster_size_configuration.md) · [Configuration Reference](docs/configuration-reference.md) |
 | **Architecture** | [Values Inheritance Pattern](docs/values_inheritance_pattern.md) |
 | **Policy System** | [Kyverno Modular Design](docs/kyverno_modular_design.md) |
 | **Storage Policies** | [Kyverno Access Mode Policy](docs/kyverno_access_mode_policy.md) |
@@ -169,6 +169,8 @@ Comprehensive documentation is available in the `/docs` folder:
 | **CI/CD** | [Workflow Documentation](.github/workflows/README.md) |
 
 Additional documentation:
+- **Configuration reference**: [docs/configuration-reference.md](docs/configuration-reference.md) — Root helmParameters, script env vars, platform gates
+- **Install helpers**: [scripts/README.md](scripts/README.md)
 - **SBOM**: See `/sbom` folder for software bill of materials generation and validation
 
 ## 📝 License

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1,0 +1,60 @@
+# Configuration reference
+
+Cluster-Forge configuration variables used outside Helm chart `values.yaml` files:
+root Argo CD `helmParameters`, install scripts, and platform gate helpers.
+
+## Root chart Argo CD helmParameters
+
+| Application | Parameter | Default (root) | Purpose |
+|-------------|-----------|----------------|---------|
+| `aim-engine` | `clusterRuntimeConfig.enable` | `false` | When `false`, the aim-engine chart does not render `AIMClusterRuntimeConfig`. Set `true` for OpenShift/manual installs that need aim-engine-managed routing (see `docs/openshift/install.sh` and `docs/manual_helm_install/scripts/install_base.sh`). |
+
+Defined in `root/values.yaml` under `apps.<app>.helmParameters`.
+
+## AI Gateway webhook TLS (prevention vs heal)
+
+Mainline clusters issue the envoy-ai-gateway mutating webhook serving cert via
+cert-manager (`controller.mutatingWebhook.certManager.enable: true` in
+`root/values.yaml`). ca-injector keeps `clientConfig.caBundle` aligned with the
+issued Certificate.
+
+The heal script below is for legacy genCA clusters, post-cutover recovery, and
+operator runbooks when drift still occurs (EAI-8292).
+
+## `scripts/ai-gateway-webhook-health.sh`
+
+Probe and heal the envoy-ai-gateway pod mutating webhook. Defaults match the
+`envoy-ai-gateway` chart.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `WEBHOOK_NAME` | `envoy-ai-gateway-gateway-pod-mutator.envoy-ai-gateway-system` | `MutatingWebhookConfiguration` resource name |
+| `SECRET_NAMESPACE` | `envoy-ai-gateway-system` | Namespace of the webhook TLS secret |
+| `SECRET_NAME` | `self-signed-cert-for-mutating-webhook` | Secret containing `ca.crt` |
+| `CONTROLLER_NAMESPACE` | `envoy-ai-gateway-system` | AI Gateway controller namespace |
+| `CONTROLLER_DEPLOYMENT` | `ai-gateway-controller` | Deployment restarted during heal |
+| `GATEWAY_NAMESPACE` | `envoy-gateway-system` | Namespace for probe pods and Envoy data-plane restarts |
+| `APPS_GATEWAY_NAME` | `https` | Apps Gateway checked after heal |
+| `AI_GATEWAY_NAME` | `ai-gateway` | AI Gateway checked after heal (skipped when absent) |
+
+Flags: `--probe-only` (no heal). Healing always restarts https and ai-gateway Envoy
+data-plane Deployments and verifies Gateway `Programmed=True` before exit 0.
+
+## `scripts/platform-gates/`
+
+Post-handoff cluster checks. See [`scripts/platform-gates/README.md`](../scripts/platform-gates/README.md).
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `PLATFORM_DOMAIN` | *(required)* | Cluster apex domain for HTTPS gate |
+| `CLUSTERFORGE_RELEASE` | `unknown` in report | Recorded in gate report metadata only |
+| `PLATFORM_GATES_HOST` | `hostname -f` | Hostname recorded in report metadata |
+| `PLATFORM_GATES_REPORT` | `~/platform-gates-report.txt` | Output path for `run-all.sh` |
+| `PLATFORM_GATES_BLOOM_LOG` | `~/bloom-cli.log` | Bloom log tail on gate failure |
+| `PLATFORM_GATES_BLOOM_LOG_TAIL` | `50` | Lines of bloom log included on failure |
+| `PLATFORM_GATES_CURL_TIMEOUT` | `30` | Seconds for `https-aiwb-ui.sh` curl |
+| `GATEWAY_NAMESPACE` | `envoy-gateway-system` | Namespace for gateway programmed gate |
+| `APPS_GATEWAY_NAME` | `https` | Apps Gateway name |
+| `AI_GATEWAY_NAME` | `ai-gateway` | AI Gateway name (skipped when absent) |
+
+Webhook gate env vars are inherited from `ai-gateway-webhook-health.sh`.

--- a/docs/openshift/install.sh
+++ b/docs/openshift/install.sh
@@ -2241,64 +2241,27 @@ step_copy_objects() {
 # ============================================================================
 # CUSTOM STEP: AI GATEWAY POD-MUTATING WEBHOOK
 # ============================================================================
-# Check that the AI gateway's pod-mutating webhook is answering, and restart the
-# controller if it is not.
+# Probe (and heal) the envoy-ai-gateway pod mutating webhook via the shared
+# cluster-forge script. Mainline clusters issue the webhook cert via cert-manager
+# (see root/values.yaml); legacy genCA clusters or post-cutover drift can still
+# leave clientConfig.caBundle out of sync with the controller TLS secret. With
+# failurePolicy: Fail that blocks Envoy data-plane pod creation.
 #
-# The envoy-ai-gateway chart mints a fresh self-signed certificate on every
-# render, so each run rotates that webhook's keypair and caBundle together. The
-# controller normally reloads the new certificate. If it ever did not, the webhook
-# has failurePolicy: Fail on pod CREATE and would stop the Envoy data plane from
-# ever being recreated, while leaving every other workload alone -- its
-# objectSelector only matches app.kubernetes.io/managed-by: envoy-gateway. A
-# cluster in that state looks healthy until something deletes an Envoy pod.
-#
-# Custom because it is neither an install nor a read-back: the question is whether
-# admission accepts a pod it would mutate, which is answered by asking the API
-# server to admit one and throw it away.
+# Custom because it is neither an install nor a read-back: admission must accept a
+# probe pod, and healing syncs caBundle, restarts the controller, and rolls the
+# https and ai-gateway Envoy data planes.
 step_ai_gateway_webhook_probe() {
   local app="$1"
+  local ai_gateway_webhook_health="${CLUSTER_FORGE_DIR}/cluster-forge/scripts/ai-gateway-webhook-health.sh"
 
-  # --dry-run=server runs the full admission chain, this webhook included, and
-  # persists nothing. The labels are what its objectSelector matches; without them
-  # the webhook is never consulted and the probe proves nothing.
-  probe_pod() {
-    kubectl apply --dry-run=server -f - >/dev/null 2>&1 <<'PROBE'
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ai-gateway-webhook-probe
-  namespace: envoy-gateway-system
-  labels:
-    app.kubernetes.io/managed-by: envoy-gateway
-spec:
-  containers:
-    - name: probe
-      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
-      command: ["sleep", "1"]
-PROBE
-  }
-
-  if probe_pod; then
-    echo "✅ ${app}: pod-mutating webhook is admitting pods"
-    return 0
+  if [[ ! -x "${ai_gateway_webhook_health}" ]]; then
+    echo "❌ ${ai_gateway_webhook_health} not found or not executable" >&2
+    exit 1
   fi
 
-  echo "⚠️  ${app}: the pod-mutating webhook is rejecting pods; restarting the controller to reload its certificate"
-  kubectl rollout restart deploy/ai-gateway-controller -n envoy-ai-gateway-system
-  kubectl rollout status deploy/ai-gateway-controller -n envoy-ai-gateway-system --timeout=180s
-
-  if probe_pod; then
-    echo "✅ ${app}: webhook healthy after the restart"
-    return 0
-  fi
-
-  # Fatal, unlike install-old.sh, which prints the same finding and carries on. A
-  # webhook rejecting pods means the data plane cannot be recreated, and every
-  # later step that expects the gateway to serve would fail further from the cause.
-  echo "❌ ${app}: the webhook is still rejecting pods after a controller restart." >&2
-  echo "   The Envoy data plane cannot be recreated until this is fixed. Check:" >&2
-  echo "     kubectl logs -n envoy-ai-gateway-system deploy/ai-gateway-controller" >&2
-  exit 1
+  # Shared with mainline cluster-forge (see scripts/ai-gateway-webhook-health.sh).
+  "${ai_gateway_webhook_health}"
+  echo "✅ ${app}: pod-mutating webhook healthy"
 }
 
 # ============================================================================

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,6 @@
+# Cluster-Forge scripts
+
+Supported install/operator helpers. Backup and restore **examples** live in [`utils/`](utils/README.md) and are not covered here.
+
+- `ai-gateway-webhook-health.sh` — Probe (and heal) the envoy-ai-gateway pod mutating webhook when `clientConfig.caBundle` drifts from the controller TLS secret. Mainline clusters prevent drift via cert-manager (`root/values.yaml`); use this script for legacy clusters, post-cutover recovery, and operator runbooks. Healing syncs caBundle, restarts the controller, rolls https and ai-gateway Envoy data-plane Deployments, and verifies Gateway `Programmed=True`. Used by OpenShift `docs/openshift/install.sh`; operators may run it on RKE2/mainline clusters. Override chart names via environment variables (`WEBHOOK_NAME`, `SECRET_NAME`, and related vars; see `--help`). Use `--probe-only` for platform gate checks (no heal).
+- [`platform-gates/`](platform-gates/README.md) — Post-handoff platform checks (Gateway programmed, webhook probe, HTTPS AIWB UI) with a mandatory report artifact for Kaytoo validation and future shared-cluster CI.

--- a/scripts/ai-gateway-webhook-health.sh
+++ b/scripts/ai-gateway-webhook-health.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Probe and heal the envoy-ai-gateway pod mutating webhook.
+#
+# Mainline cluster-forge enables cert-manager for webhook certs (root/values.yaml).
+# This script covers legacy genCA clusters and post-cutover drift: the webhook uses
+# failurePolicy: Fail and only matches pods labeled app.kubernetes.io/managed-by=envoy-gateway.
+# When clientConfig.caBundle drifts from the controller TLS secret, Envoy HTTPS
+# data-plane pods cannot be created.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Probe and heal the envoy-ai-gateway pod mutating webhook.
+
+Usage:
+  ai-gateway-webhook-health.sh [--probe-only]
+
+Exit 0 when the webhook accepts probe pod CREATE (dry-run/server) and, after a
+heal, when https and ai-gateway Gateway resources report Programmed=True.
+With --probe-only, fail without healing (for platform gate / CI checks).
+Healing syncs caBundle, restarts the controller, rolls both https and ai-gateway
+Envoy data-plane Deployments, then verifies gateway Programmed status.
+
+Environment (defaults match the envoy-ai-gateway chart):
+  WEBHOOK_NAME
+  SECRET_NAMESPACE
+  SECRET_NAME
+  CONTROLLER_NAMESPACE
+  CONTROLLER_DEPLOYMENT
+  GATEWAY_NAMESPACE
+  APPS_GATEWAY_NAME
+  AI_GATEWAY_NAME
+EOF
+}
+
+WEBHOOK_NAME="${WEBHOOK_NAME:-envoy-ai-gateway-gateway-pod-mutator.envoy-ai-gateway-system}"
+SECRET_NAMESPACE="${SECRET_NAMESPACE:-envoy-ai-gateway-system}"
+SECRET_NAME="${SECRET_NAME:-self-signed-cert-for-mutating-webhook}"
+CONTROLLER_NAMESPACE="${CONTROLLER_NAMESPACE:-envoy-ai-gateway-system}"
+CONTROLLER_DEPLOYMENT="${CONTROLLER_DEPLOYMENT:-ai-gateway-controller}"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-envoy-gateway-system}"
+APPS_GATEWAY_NAME="${APPS_GATEWAY_NAME:-https}"
+AI_GATEWAY_NAME="${AI_GATEWAY_NAME:-ai-gateway}"
+PROBE_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --probe-only)
+      PROBE_ONLY=1
+      shift
+      ;;
+    --heal-envoy-data-plane)
+      # Backward compat: heal always restarts Envoy data planes now.
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+probe_ai_gateway_webhook() {
+  kubectl apply --dry-run=server -f - >/dev/null 2>&1 <<PROBE
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-gateway-webhook-probe
+  namespace: ${GATEWAY_NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: envoy-gateway
+spec:
+  containers:
+    - name: probe
+      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      command: ["sleep", "1"]
+PROBE
+}
+
+sync_webhook_ca_from_secret() {
+  local secret_ca webhook_ca
+  secret_ca="$(kubectl get secret "${SECRET_NAME}" -n "${SECRET_NAMESPACE}" -o jsonpath='{.data.ca\.crt}')"
+  if [[ -z "${secret_ca}" ]]; then
+    echo "secret ${SECRET_NAMESPACE}/${SECRET_NAME} missing ca.crt" >&2
+    return 1
+  fi
+  webhook_ca="$(kubectl get mutatingwebhookconfigurations "${WEBHOOK_NAME}" -o jsonpath='{.webhooks[0].clientConfig.caBundle}')"
+  if [[ "${secret_ca}" == "${webhook_ca}" ]]; then
+    return 0
+  fi
+  echo "syncing webhook caBundle from ${SECRET_NAMESPACE}/${SECRET_NAME}"
+  # RFC 6902 "add" inserts or replaces an object member, so this works when
+  # caBundle is missing (cert-manager inject path) or present but stale.
+  kubectl patch mutatingwebhookconfigurations "${WEBHOOK_NAME}" --type=json \
+    --patch="[{\"op\":\"add\",\"path\":\"/webhooks/0/clientConfig/caBundle\",\"value\":\"${secret_ca}\"}]"
+}
+
+restart_ai_gateway_controller() {
+  kubectl rollout restart "deployment/${CONTROLLER_DEPLOYMENT}" -n "${CONTROLLER_NAMESPACE}" >/dev/null
+  kubectl rollout status "deployment/${CONTROLLER_DEPLOYMENT}" -n "${CONTROLLER_NAMESPACE}" --timeout=180s
+}
+
+restart_envoy_data_plane() {
+  local deployments
+  deployments="$(kubectl get deployment -n "${GATEWAY_NAMESPACE}" \
+    -l 'gateway.envoyproxy.io/owning-gateway-name in (https,ai-gateway)' \
+    -o name 2>/dev/null || true)"
+  if [[ -z "${deployments}" ]]; then
+    echo "no envoy gateway data-plane deployments to restart" >&2
+    return 0
+  fi
+  kubectl rollout restart deployment \
+    -l 'gateway.envoyproxy.io/owning-gateway-name in (https,ai-gateway)' \
+    -n "${GATEWAY_NAMESPACE}" >/dev/null
+  kubectl rollout status deployment \
+    -l 'gateway.envoyproxy.io/owning-gateway-name in (https,ai-gateway)' \
+    -n "${GATEWAY_NAMESPACE}" --timeout=180s
+}
+
+verify_gateways_programmed() {
+  local name programmed
+  for name in "${APPS_GATEWAY_NAME}" "${AI_GATEWAY_NAME}"; do
+    if ! kubectl get gateway "${name}" -n "${GATEWAY_NAMESPACE}" >/dev/null 2>&1; then
+      continue
+    fi
+    if ! kubectl wait --for=condition=Programmed gateway/"${name}" \
+      -n "${GATEWAY_NAMESPACE}" --timeout=180s; then
+      echo "gateway ${GATEWAY_NAMESPACE}/${name} not Programmed after heal" >&2
+      kubectl describe gateway "${name}" -n "${GATEWAY_NAMESPACE}" >&2 || true
+      return 1
+    fi
+    programmed="$(kubectl get gateway "${name}" -n "${GATEWAY_NAMESPACE}" \
+      -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}')"
+    if [[ "${programmed}" != "True" ]]; then
+      echo "gateway ${GATEWAY_NAMESPACE}/${name} Programmed=${programmed}" >&2
+      kubectl describe gateway "${name}" -n "${GATEWAY_NAMESPACE}" >&2 || true
+      return 1
+    fi
+    echo "gateway ${GATEWAY_NAMESPACE}/${name} Programmed=True"
+  done
+}
+
+heal_ai_gateway_webhook() {
+  sync_webhook_ca_from_secret || true
+  restart_ai_gateway_controller
+  restart_envoy_data_plane
+}
+
+if probe_ai_gateway_webhook; then
+  echo "Pod-mutating webhook healthy"
+  exit 0
+fi
+
+if [[ "${PROBE_ONLY}" -eq 1 ]]; then
+  echo "Pod-mutating webhook is rejecting pods (probe-only; not healing)" >&2
+  exit 1
+fi
+
+echo "Pod-mutating webhook is rejecting pods; healing"
+heal_ai_gateway_webhook
+
+if probe_ai_gateway_webhook; then
+  if verify_gateways_programmed; then
+    echo "Webhook and Envoy gateways healthy after heal"
+    exit 0
+  fi
+  echo "Webhook accepts pods but Envoy gateway(s) not Programmed after heal" >&2
+  exit 1
+fi
+
+echo "Webhook still rejecting pods — Envoy data plane cannot be recreated until this is fixed" >&2
+exit 1

--- a/scripts/platform-gates/README.md
+++ b/scripts/platform-gates/README.md
@@ -1,0 +1,54 @@
+# Platform gates
+
+Post-handoff checks for a bloomed cluster: Envoy Gateway programming, AI Gateway
+admission webhook trust, and external HTTPS to AI Workbench UI.
+
+Run after bloom (and after any readiness gate such as AIWB API rollout). These
+assertions catch regressions that internal API health checks can miss — for
+example mutating webhook CA drift blocking Envoy HTTPS data-plane pods while
+in-cluster `/v1/health` still returns OK. Webhook TLS is normally issued by
+cert-manager on mainline clusters; the webhook gate probes admission and does
+not heal during CI.
+
+## Usage
+
+On the cluster head (kubeconfig at `/root/.kube/config` after bloom):
+
+```bash
+export PLATFORM_DOMAIN=<cluster-domain>   # bloom apex DOMAIN (see root/values.yaml)
+export CLUSTERFORGE_RELEASE=v2.2.2        # optional metadata for the report
+sudo KUBECONFIG=/root/.kube/config \
+  scripts/platform-gates/run-all.sh \
+  --report ~/platform-gates-report.txt
+```
+
+From a dev VM with SSH access to the bloom head, stage this repo’s `scripts/platform-gates/`
+on the host and run the same `run-all.sh` command with `PLATFORM_DOMAIN` set to the
+cluster’s apex domain.
+
+## Gates (in order)
+
+| Gate | Script | Pass criteria |
+|------|--------|---------------|
+| Gateway programmed | `gateway-programmed.sh` | Gateway `https` (and `ai-gateway` when present) has `Programmed=True` |
+| AI Gateway webhook | `ai-gateway-webhook.sh` | Probe pod CREATE accepted (`--probe-only`; no heal). Heal path (operators) also rolls https + ai-gateway data planes and verifies `Programmed=True`. |
+| HTTPS AIWB UI | `https-aiwb-ui.sh` | `curl -sfI` to `https://aiwbui.<domain>/` via gateway LB IP (`--resolve`; avoids hairpin NAT failures from the head node) |
+
+## Report artifact
+
+`run-all.sh` always writes `~/platform-gates-report.txt` (override with
+`--report` or `PLATFORM_GATES_REPORT`). The file is the merge/review artifact:
+paste the full contents into a PR comment. On failure the report includes the
+last lines of `~/bloom-cli.log` when that file exists on the host.
+
+## Environment
+
+| Variable | Purpose |
+|----------|---------|
+| `PLATFORM_DOMAIN` | Cluster apex domain from bloom config (required for HTTPS gate) |
+| `CLUSTERFORGE_RELEASE` | Recorded in report metadata only |
+| `PLATFORM_GATES_HOST` | Hostname recorded in report metadata |
+| `PLATFORM_GATES_REPORT` | Report path (default `~/platform-gates-report.txt`) |
+| `KUBECONFIG` | kubectl config (use `/root/.kube/config` on bloom head) |
+
+Webhook gate env vars are documented in `../ai-gateway-webhook-health.sh`.

--- a/scripts/platform-gates/ai-gateway-webhook.sh
+++ b/scripts/platform-gates/ai-gateway-webhook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Platform gate: mutating webhook accepts probe pods (no heal).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/../ai-gateway-webhook-health.sh" --probe-only

--- a/scripts/platform-gates/gateway-programmed.sh
+++ b/scripts/platform-gates/gateway-programmed.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Assert Envoy Gateway resources report Programmed=True.
+set -euo pipefail
+
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-envoy-gateway-system}"
+APPS_GATEWAY="${APPS_GATEWAY_NAME:-https}"
+AI_GATEWAY="${AI_GATEWAY_NAME:-ai-gateway}"
+
+check_gateway() {
+  local name="$1"
+  if ! kubectl get gateway "${name}" -n "${GATEWAY_NAMESPACE}" >/dev/null 2>&1; then
+    echo "gateway ${GATEWAY_NAMESPACE}/${name} not found (skipped)"
+    return 0
+  fi
+  kubectl wait --for=condition=Programmed gateway/"${name}" \
+    -n "${GATEWAY_NAMESPACE}" --timeout=120s
+  local programmed
+  programmed="$(kubectl get gateway "${name}" -n "${GATEWAY_NAMESPACE}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}')"
+  if [[ "${programmed}" != "True" ]]; then
+    echo "gateway ${GATEWAY_NAMESPACE}/${name} Programmed=${programmed}" >&2
+    kubectl describe gateway "${name}" -n "${GATEWAY_NAMESPACE}" >&2 || true
+    return 1
+  fi
+  echo "gateway ${GATEWAY_NAMESPACE}/${name} Programmed=True"
+}
+
+check_gateway "${APPS_GATEWAY}"
+check_gateway "${AI_GATEWAY}"

--- a/scripts/platform-gates/https-aiwb-ui.sh
+++ b/scripts/platform-gates/https-aiwb-ui.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# HTTPS smoke: AI Workbench UI via the apps Envoy Gateway.
+#
+# Uses the gateway LoadBalancer IP with curl --resolve so the check works from
+# the cluster head (Kaytoo/int-test) where hairpin NAT to the public VIP often fails.
+set -euo pipefail
+
+DOMAIN="${PLATFORM_DOMAIN:?PLATFORM_DOMAIN is required}"
+HOST="aiwbui.${DOMAIN}"
+URL="https://${HOST}/"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-envoy-gateway-system}"
+APPS_GATEWAY="${APPS_GATEWAY_NAME:-https}"
+CURL_TIMEOUT="${PLATFORM_GATES_CURL_TIMEOUT:-30}"
+
+lb_ip="$(kubectl get gateway "${APPS_GATEWAY}" -n "${GATEWAY_NAMESPACE}" \
+  -o jsonpath='{.status.addresses[?(@.type=="IPAddress")].value}' 2>/dev/null | head -1)"
+
+if [[ -z "${lb_ip}" ]]; then
+  lb_ip="$(kubectl get svc -n "${GATEWAY_NAMESPACE}" \
+    -l "gateway.envoyproxy.io/owning-gateway-name=${APPS_GATEWAY}" \
+    -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+fi
+
+if [[ -n "${lb_ip}" ]]; then
+  echo "GET ${URL} via gateway LB ${lb_ip} (--resolve)"
+  curl -sfI --max-time "${CURL_TIMEOUT}" \
+    --resolve "${HOST}:443:${lb_ip}" \
+    "${URL}"
+else
+  echo "GET ${URL} (direct; gateway LB IP not found in status)"
+  curl -sfI --max-time "${CURL_TIMEOUT}" "${URL}"
+fi
+
+echo "HTTPS ${URL} OK"

--- a/scripts/platform-gates/run-all.sh
+++ b/scripts/platform-gates/run-all.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Run platform gates and write a mandatory report artifact.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPORT_PATH="${PLATFORM_GATES_REPORT:-${HOME}/platform-gates-report.txt}"
+BLOOM_LOG="${PLATFORM_GATES_BLOOM_LOG:-${HOME}/bloom-cli.log}"
+BLOOM_LOG_TAIL_LINES="${PLATFORM_GATES_BLOOM_LOG_TAIL:-50}"
+
+GATES=(
+  gateway-programmed
+  ai-gateway-webhook
+  https-aiwb-ui
+)
+
+usage() {
+  sed -n '2,20p' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --report)
+      REPORT_PATH="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${PLATFORM_DOMAIN:-}" ]]; then
+  echo "PLATFORM_DOMAIN is required (cluster apex domain)" >&2
+  exit 2
+fi
+
+started_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+overall="PASS"
+declare -a gate_names=()
+declare -a gate_statuses=()
+declare -a gate_details=()
+
+write_report() {
+  {
+    echo "=== Platform gates report ==="
+    echo "Host: ${PLATFORM_GATES_HOST:-$(hostname -f 2>/dev/null || hostname)}"
+    echo "ClusterForge release: ${CLUSTERFORGE_RELEASE:-unknown}"
+    echo "Domain: ${PLATFORM_DOMAIN}"
+    echo "Started: ${started_at}"
+    echo ""
+    local index
+    for index in "${!gate_names[@]}"; do
+      echo "[${gate_names[$index]}] ${gate_statuses[$index]}"
+      echo "${gate_details[$index]}" | sed 's/^/  /'
+      echo ""
+    done
+    if [[ "${overall}" != "PASS" && -f "${BLOOM_LOG}" ]]; then
+      echo "[bloom-log-tail] last ${BLOOM_LOG_TAIL_LINES} lines of ${BLOOM_LOG}"
+      tail -n "${BLOOM_LOG_TAIL_LINES}" "${BLOOM_LOG}" | sed 's/^/  /'
+      echo ""
+    fi
+    echo "Finished: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    echo "Overall: ${overall}"
+  } > "${REPORT_PATH}"
+}
+
+run_gate() {
+  local gate="$1"
+  local output
+  local status=0
+  set +e
+  output="$("${SCRIPT_DIR}/${gate}.sh" 2>&1)"
+  status=$?
+  set -e
+  gate_names+=("${gate}")
+  if [[ "${status}" -eq 0 ]]; then
+    gate_statuses+=("PASS")
+  else
+    gate_statuses+=("FAIL")
+    overall="FAIL"
+  fi
+  gate_details+=("${output}")
+  return "${status}"
+}
+
+for gate in "${GATES[@]}"; do
+  run_gate "${gate}" || true
+done
+
+write_report
+cat "${REPORT_PATH}"
+
+if [[ "${overall}" == "PASS" ]]; then
+  exit 0
+fi
+exit 1

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Offline tests for install helpers (no cluster required).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $*"
+}
+
+test_help_exits_zero() {
+  local script="$1"
+  "${script}" --help >/dev/null
+  pass "${script} --help"
+}
+
+test_help_exits_zero scripts/ai-gateway-webhook-health.sh
+test_help_exits_zero scripts/platform-gates/run-all.sh
+
+unknown_arg_status=0
+scripts/ai-gateway-webhook-health.sh --not-a-flag >/dev/null 2>&1 || unknown_arg_status=$?
+[[ "${unknown_arg_status}" -eq 2 ]] || fail "ai-gateway-webhook-health.sh unknown arg should exit 2"
+pass "ai-gateway-webhook-health.sh rejects unknown flags"
+
+rendered="$(mktemp)"
+trap 'rm -f "${rendered}"' EXIT
+
+helm template test sources/envoy-ai-gateway/v1.0.0 \
+  --namespace envoy-ai-gateway-system \
+  --set controller.mutatingWebhook.certManager.enable=true \
+  > "${rendered}"
+
+grep -q 'kind: MutatingWebhookConfiguration' "${rendered}" \
+  || fail "envoy-ai-gateway render missing MutatingWebhookConfiguration"
+
+grep -q 'cert-manager.io/inject-ca-from: envoy-ai-gateway-system/self-signed-cert-for-mutating-webhook' "${rendered}" \
+  || fail "envoy-ai-gateway cert-manager path missing inject-ca-from annotation"
+
+grep -q 'kind: Certificate' "${rendered}" \
+  || fail "envoy-ai-gateway cert-manager path missing Certificate"
+
+grep -q 'kind: Issuer' "${rendered}" \
+  || fail "envoy-ai-gateway cert-manager path missing Issuer"
+
+if grep -E '^[[:space:]]+caBundle:' "${rendered}" >/dev/null; then
+  fail "envoy-ai-gateway cert-manager path must not embed clientConfig.caBundle"
+fi
+pass "envoy-ai-gateway cert-manager webhook path renders Certificate, Issuer, and inject-ca-from"
+
+echo "All script tests passed."


### PR DESCRIPTION
## Summary

Complements #824 (cert-manager webhook TLS prevention) with detect/heal tooling and post-handoff validation. Chart template changes for genCA `caBundle` embedding were dropped — mainline prevention is cert-manager via `root/values.yaml`.

- Add `scripts/ai-gateway-webhook-health.sh` — probe → sync CA from secret → restart controller → roll https + ai-gateway data planes → verify Gateway `Programmed=True`
- Add `scripts/platform-gates/` — Gateway programmed, webhook probe-only, HTTPS AIWB UI, mandatory report artifact
- Wire OpenShift `install.sh` to the shared heal script
- CI: `install-script-checks` job runs offline helper tests (cert-manager webhook render path)

Fixes the k2 incident where `https://aiwbui.<domain>/` failed with connection closed despite healthy app pods — Gateway `Programmed=False`, `Envoy replicas unavailable`.

Jira: https://amd.atlassian.net/browse/EAI-8292

## Test plan

- [x] `scripts/test/run-tests.sh` — cert-manager path renders Certificate, Issuer, and inject-ca-from (no baked caBundle)
- [x] `helm template envoy-ai-gateway sources/envoy-ai-gateway/v1.0.0 --namespace envoy-ai-gateway-system` with mainline `valuesObject` from `root/values.yaml`
- [x] Fresh mainline deploy (k2 / `wookie.silogen.ai`): `gateway/https` and `gateway/ai-gateway` `Programmed=True`
- [x] Webhook probe: `scripts/ai-gateway-webhook-health.sh --probe-only` exits 0
- [x] Envoy data-plane pods: `https` + `ai-gateway` deployments `2/2 Running`
- [x] `https://aiwbui.wookie.silogen.ai/` TLS OK (307 → sign-in) via gateway LB `--resolve`
- [x] `https://argocd.wookie.silogen.ai/` returns 200 via gateway LB `--resolve`
- [x] Drift → heal → data planes recover — validated on chalupa-491a (self-signed drift); **not reproducible on k2** (cert-manager ca-injector + ArgoCD revert caBundle patches immediately)
- [ ] OpenShift install path