### PR TITLE
Issue the ai-gateway webhook cert via cert-manager

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -701,6 +701,27 @@ apps:
         mcp:
           sessionEncryption:
             seed: "cluster-forge-default-seed-override-in-production"
+        mutatingWebhook:
+          # Issue the webhook serving cert via cert-manager instead of the chart's
+          # built-in Helm genCA path, which upstream's own values.yaml calls "not
+          # recommended for production use".
+          #
+          # The genCA path guards regeneration with `lookup "v1" "Secret" ...`, and
+          # lookup returns empty whenever Helm renders without a live cluster — which
+          # is exactly how ArgoCD renders. So every sync mints a fresh CA and rewrites
+          # the MutatingWebhookConfiguration caBundle, while the running controller
+          # keeps serving the cert it loaded at startup. The two drift apart and pod
+          # admission fails with "x509: certificate signed by unknown authority".
+          # Because failurePolicy is Fail, the ai-gateway proxy ReplicaSet can then no
+          # longer create pods, so the extproc sidecar is never injected and every
+          # inference request dies with an empty 500 (seen on int-test).
+          #
+          # With cert-manager the Certificate and Issuer are declarative and ca-injector
+          # keeps the caBundle in sync with the issued cert, so a re-render cannot
+          # desynchronise them. cert-manager is already installed at syncWave -40, well
+          # ahead of this app at -5.
+          certManager:
+            enable: true
       extProc:
         image:
           tag: 8007dfd481f7d1225bcaf9d059cb15b61d4d28e0


### PR DESCRIPTION
## Summary

Enable the chart's cert-manager path for the ai-gateway mutating webhook serving cert, instead of the built-in Helm `genCA` path.

```yaml
controller:
  mutatingWebhook:
    certManager:
      enable: true
```

## Why

On int-test the CA advertised in the `MutatingWebhookConfiguration` stopped matching the cert the controller served, and pod admission began failing:

```
x509: certificate signed by unknown authority ("ai-gateway-controller-ca")
```

The webhook is `failurePolicy: Fail` and selects envoy-gateway managed pods, so the ai-gateway proxy Deployment could no longer create pods. It sat at `UP-TO-DATE: 0` for 14h, still serving from a ReplicaSet created during cluster bring-up whose Envoy configuration was stale:

```
deploy/envoy-envoy-gateway-system-ai-gateway-78adb12c   UP-TO-DATE: 0
ReplicaFailure  True  FailedCreate   (webhook call)
Progressing     False ProgressDeadlineExceeded
```

Every inference request returned an empty `500`, identically with a valid key, an invalid key, or no key at all, because requests died before authorization was reached. That is indistinguishable from an auth failure and was initially reported as one. Recovery required deleting the webhook by hand so the Deployment could roll.

**Scope of the claim:** exactly how the CA and the served cert diverged is not established, and the original pod is gone so it can no longer be determined. What this PR addresses is the structural weakness that allows it: the `genCA` path leaves two copies of the trust material that must agree, the `caBundle` written into the webhook object and the cert in the Secret the controller mounts, with nothing keeping them consistent once either is rewritten. Upstream's own `values.yaml` describes that path as "not recommended for production use".

With cert-manager the Certificate and Issuer are declarative and ca-injector maintains the `caBundle` from the issued cert, so the two cannot drift apart.

## Verification

Rendered both ways:

```
default:        Secret (Helm genCA) + MutatingWebhookConfiguration with baked caBundle
certManager:    Certificate + Issuer + MutatingWebhookConfiguration with
                cert-manager.io/inject-ca-from, no baked caBundle
```

- Both paths populate `self-signed-cert-for-mutating-webhook`, which is the Secret the controller mounts as its `certs` volume (`deployment.yaml`).
- cert-manager, cainjector and webhook all confirmed Running on int-test.
- syncWave: cert-manager `-40`, envoy-ai-gateway `-5`, so the issuer exists first.
- `helm lint` clean.

## Deploy note

The existing cert Secret is Helm/ArgoCD-owned. On first sync it likely needs deleting so cert-manager can reissue it, then the controller restarted to pick up the new cert. **Restart the controller before the proxy** — the other order just recreates the failure.

## Risk

Low in steady state, but it does touch the admission path for envoy-gateway managed pods on every cluster. Worth landing when someone can watch the first sync, since a bad cert here blocks proxy pod creation rather than failing loudly.

## Not addressed here

- Whether this recurs, and the precise divergence mechanism. int-test currently has the webhook deleted, so it cannot recur there until ArgoCD recreates it.
- The ai-gateway-discovery `2.0.2` port issue, which is unrelated and still outstanding.
