### PR TITLE
fix(blueprint): vllm-sr remove cluster-auth references

### DIFF
--- a/root-extras/blueprints/semantic-router/README.md
+++ b/root-extras/blueprints/semantic-router/README.md
@@ -97,8 +97,8 @@ Three files, all fetched into your cluster-values overlay repo:
 
    `sr.<domain>` has no authentication of its own by default — anyone who can
    reach the hostname can spend your GPU capacity. Decide now whether to gate
-   it; see "Reaching the router" below for the annotation that requires a
-   `cluster-auth` group.
+   it; see "Reaching the router" below for the SecurityPolicy example that
+   gates it with an API key.
 
 4. Review and push:
 
@@ -402,23 +402,28 @@ so anyone who can reach the hostname can spend your GPU capacity. Unlike
 on `ai-gateway`, which this blueprint deliberately leaves alone. Put an auth layer
 in front of it before exposing it to anyone you would not hand a GPU to.
 
-`cluster-auth`'s ext_authz already runs against every route on the shared
-`https` Gateway, including this one — but its default policy set only requires
-auth for `admin`-role callers, so `sr.<domain>` passes through unauthenticated
-by default just like any other new route. To require a specific group, annotate
-the `HTTPRoute` in `gateway-routing.yaml`:
+A commented `SecurityPolicy` in `gateway-routing.yaml`, right after the
+`EnvoyExtensionPolicy`, gates the route with a client API key: a bearer token
+in the `Authorization` header is checked against a Secret, stripped before the
+request reaches the router or backend, and a mismatch is a 401 before either
+sees it. Unlike synopsys's own version of this (`sr-api-apikey`, bolted onto a
+second bridge `HTTPRoute` because its real route is `AIGatewayRoute`-generated
+and can't carry a policy directly), this blueprint's `HTTPRoute` is
+hand-authored, so the policy targets it directly — same namespace, one
+object, one Secret, no bridge route needed.
 
-```yaml
-metadata:
-  name: semantic-router
-  namespace: semantic-router
-  annotations:
-    cluster-auth/allowed-group: <your-group>
+Create the Secret directly on the cluster, not the overlay repo:
+
+```bash
+kubectl -n semantic-router create secret generic semantic-router-client-keys \
+  --from-literal=TODO-your-client-name="$(openssl rand -hex 32)"
 ```
 
-That matches cluster-auth's `httproute-group-based-access` policy
-(`requireAuth: true`), so only callers in `<your-group>` are let through; anyone
-else gets rejected before the request reaches the router or the model backend.
+Clients send the key as a bearer token:
+
+```bash
+curl https://sr.<domain>/... -H "Authorization: Bearer <the secret value>"
+```
 
 ## Timeouts, retries, and failover
 

--- a/root-extras/blueprints/semantic-router/manifests/gateway-routing.yaml
+++ b/root-extras/blueprints/semantic-router/manifests/gateway-routing.yaml
@@ -19,11 +19,6 @@ kind: HTTPRoute
 metadata:
   name: semantic-router
   namespace: semantic-router
-  # Uncomment to require cluster-auth group membership on this route. Without
-  # it, requests to sr.<domain> pass through unauthenticated — see the README's
-  # "Reaching the router" section for why.
-  # annotations:
-  #   cluster-auth/allowed-group: TODO-your-group
 spec:
   # The shared Gateway every app on a bloomed cluster routes through. Its
   # listener is a `*.<domain>` wildcard open to all namespaces, so this attaches
@@ -126,6 +121,37 @@ spec:
       # Router unreachable -> requests skip it and take the catch-all rule,
       # instead of the whole hostname returning 5xx.
       failOpen: true
+
+# Requiring a client API key on sr.<domain> — not enabled by default.
+# apiKeyAuth checks the Authorization header against a Secret's values;
+# sanitize: true strips it again before the request reaches the router or
+# backend. Same namespace as the HTTPRoute is required for both the policy
+# and the Secret. Create the Secret directly on the cluster, not the overlay
+# repo:
+#
+#   kubectl -n semantic-router create secret generic semantic-router-client-keys \
+#     --from-literal=TODO-your-client-name="$(openssl rand -hex 32)"
+#
+# ---
+# apiVersion: gateway.envoyproxy.io/v1alpha1
+# kind: SecurityPolicy
+# metadata:
+#   name: semantic-router-apikey
+#   namespace: semantic-router
+# spec:
+#   targetRefs:
+#     - group: gateway.networking.k8s.io
+#       kind: HTTPRoute
+#       name: semantic-router
+#   apiKeyAuth:
+#     credentialRefs:
+#       - group: ""
+#         kind: Secret
+#         name: semantic-router-client-keys
+#     extractFrom:
+#       - headers:
+#           - Authorization
+#     sanitize: true
 
 # Retries for transient connection failures (a backend pod restarting mid-
 # rollout, a dropped connection) — not enabled by default. Envoy's HTTP retry


### PR DESCRIPTION
Cluster-auth has been removed from the stack.
Replaced with envoy SecurityPolicy in the blueprint.