### PR TITLE
Raise ai-gateway body-authz request-body cap to 32MiB (EAI-8489)

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -12,6 +12,12 @@ externalValues:
 global:
   clusterSize:    # injected via scripts/bootstrap.sh
   domain:         # injected via scripts/bootstrap.sh
+  aiGateway:
+    # Body-authz request-body ceiling, shared by envoy-gateway-config (gateway-scoped policy) and
+    # ai-gateway-discovery (per-model catch-all policies). The catch-all policies are rule-scoped
+    # and override the gateway one per route, so both must carry the same value. Rendered through
+    # int64 below: a bare number here is a float64 and would otherwise emit 4.194304e+06.
+    bodyAuthMaxRequestBytes: 4194304
 localHelmValues:
   enabled: false
 ociRegistry:
@@ -31,6 +37,9 @@ apps:
         value: "ai.{{ .Values.global.domain }}"
       - name: controller.gateway.name
         value: ai-gateway
+      # Same ceiling envoy-gateway-config renders into the gateway-scoped policy.
+      - name: controller.bodyAuthMaxRequestBytes
+        value: "{{ .Values.global.aiGateway.bodyAuthMaxRequestBytes | int64 }}"
   aim-engine:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
     repoVersion: "0.2.5"
@@ -658,6 +667,8 @@ apps:
       # index (not dot access) because the app key contains dashes.
       - name: aiGateway.discoveryNamespace
         value: '{{ index .Values.apps "ai-gateway-discovery" "namespace" }}'
+      - name: aiGateway.bodyAuthMaxRequestBytes
+        value: "{{ .Values.global.aiGateway.bodyAuthMaxRequestBytes | int64 }}"
     namespace: envoy-gateway-system
     path: envoy-gateway-config
     syncWave: -15

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.aiGateway.enabled }}
+{{- $bodyAuthMax := .Values.aiGateway.bodyAuthMaxRequestBytes | int64 }}
+{{- if le $bodyAuthMax 0 }}{{ fail "aiGateway.bodyAuthMaxRequestBytes must be a positive integer; a float or scientific-notation value casts to 0 here and would publish maxRequestBytes: 0" }}{{ end }}
 # Gateway-scoped default-deny backstop for the `ai-gateway` Gateway (EAI-7304 cutover).
 #
 # Only model routes ride ai-gateway, so a blanket deny is safe here (unlike the shared
@@ -39,7 +41,7 @@ spec:
       # Ceiling on the header-less (model-in-body) path: a body over this returns HTTP 413 and
       # skips auth (overrides failOpen). Sized via values so large-context/image inference turns
       # are not rejected — see aiGateway.bodyAuthMaxRequestBytes.
-      maxRequestBytes: {{ .Values.aiGateway.bodyAuthMaxRequestBytes | int64 }}
+      maxRequestBytes: {{ $bodyAuthMax }}
     headersToExtAuth:
       - authorization
     http:

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -36,7 +36,10 @@ spec:
   extAuth:
     failOpen: false
     bodyToExtAuth:
-      maxRequestBytes: 65536
+      # Ceiling on the header-less (model-in-body) path: a body over this returns HTTP 413 and
+      # skips auth (overrides failOpen). Sized via values so large-context/image inference turns
+      # are not rejected — see aiGateway.bodyAuthMaxRequestBytes.
+      maxRequestBytes: {{ .Values.aiGateway.bodyAuthMaxRequestBytes | int64 }}
     headersToExtAuth:
       - authorization
     http:

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -38,3 +38,12 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
+  # Max request-body size (bytes) the body-aware extAuth filter buffers before calling
+  # ai-gateway-discovery. Envoy returns HTTP 413 (skipping auth, overriding failOpen) once a
+  # body exceeds this — so it is a hard ceiling on request size for the header-less (model-in-
+  # body) path that standard OpenAI/Anthropic clients use. The upstream default of 64KiB rejects
+  # ordinary large-context inference turns (a 200k-token coding request is ~1MB; image-bearing
+  # turns are larger). Set to 32MiB to match clients' own request ceiling; the ai-gateway
+  # ClientTrafficPolicy connection bufferLimit (50Mi) sits above it. Raising this increases the
+  # memory the extAuth path may hold per in-flight header-less request. (EAI-8489.)
+  bodyAuthMaxRequestBytes: 33554432

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -38,12 +38,13 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
-  # Max request-body size (bytes) the body-aware extAuth filter buffers before calling
-  # ai-gateway-discovery. Envoy returns HTTP 413 (skipping auth, overriding failOpen) once a
-  # body exceeds this — so it is a hard ceiling on request size for the header-less (model-in-
-  # body) path that standard OpenAI/Anthropic clients use. The upstream default of 64KiB rejects
-  # ordinary large-context inference turns (a 200k-token coding request is ~1MB; image-bearing
-  # turns are larger). Set to 32MiB to match clients' own request ceiling; the ai-gateway
-  # ClientTrafficPolicy connection bufferLimit (50Mi) sits above it. Raising this increases the
-  # memory the extAuth path may hold per in-flight header-less request. (EAI-8489.)
-  bodyAuthMaxRequestBytes: 33554432
+  # Max request-body bytes the body-aware extAuth filter buffers before calling
+  # ai-gateway-discovery. Over this Envoy returns 413 and skips auth (overriding failOpen), so it
+  # is a hard request-size ceiling on the header-less (model-in-body) path standard
+  # OpenAI/Anthropic clients use. The upstream 64KiB default rejects ordinary large-context turns
+  # (~200k tokens is ~1MB). 4MiB covers those and stays within what the authz pod receiving the
+  # body can hold (its limits.memory is 256Mi).
+  # Keep in step with controller.bodyAuthMaxRequestBytes on ai-gateway-discovery: its per-model
+  # catch-all policies are rule-scoped and override this one per route, so the lower value wins.
+  # root/values.yaml drives both from global.aiGateway.bodyAuthMaxRequestBytes. (EAI-8489.)
+  bodyAuthMaxRequestBytes: 4194304


### PR DESCRIPTION
## Problem

The shared Envoy AI Gateway (`ai-gateway`) authorizes header-less requests — model in the JSON body, no `x-ai-eg-model` / `x-ai-eg-backend` routing header — via a body-aware extAuth call to `ai-gateway-discovery`. That extAuth buffers the request body at `maxRequestBytes: 65536` (64 KiB). Per the Envoy Gateway API, a body over that limit returns **HTTP 413 and skips authorization entirely** (this precedence holds even over `failOpen`).

So any large request on the header-less path is rejected before it reaches the model. This is **gateway-wide** — it hits every model on `ai-gateway` (verified on Qwen3.8-27B and MiniMax-M2.5), not one model. Standard OpenAI/Anthropic clients (e.g. Claude Code) put the model in the body and routinely send 200 KB–2 MB requests (a ~200k-token coding turn is ~1 MB; image-bearing turns are larger), so they 413 consistently.

Evidence (direct to the gateway, bypassing the translation proxy): ~67 KB body passes, 120 KB+ returns HTTP 413 (HTTP/2, `text/plain`, Envoy listener shape — not the gateway JSON error). The live Envoy config on the `ai-gateway` pod shows `with_request_body.max_request_bytes: 65536` on the BUFFERED body filter.

## Change

Parameterize the limit as `aiGateway.bodyAuthMaxRequestBytes` (default **32 MiB = 33554432**) and reference it from the `ai-gateway-default-deny` SecurityPolicy. 32 MiB matches clients' own request ceiling and sits under the existing `ai-gateway` `ClientTrafficPolicy` connection `bufferLimit` (50 Mi). The `bodyToExtAuth` API exposes only `maxRequestBytes` (no `allowPartialMessage`), so raising the ceiling is the only lever in the current Envoy Gateway version.

Rendered via `int64` to avoid Helm emitting the value in scientific notation (which would fail the integer schema).

**Tradeoff:** a larger buffer increases the memory the extAuth path can hold per in-flight header-less request. The value is now tunable per environment, so an overlay can lower it.

## Test plan

- [x] `helm template` renders `maxRequestBytes: 33554432` (integer, not `3.3e+07`) when `aiGateway.enabled=true`; renders nothing when disabled.
- [ ] After ArgoCD sync on a cluster with `ai-gateway` enabled: a >64 KB header-less request that previously 413'd is authorized and reaches the model; small-body auth behavior unchanged.

Fixes EAI-8489.