### PR TITLE
[EAI-8489]: Raise ai-gateway body-authz request-body cap to 4MiB

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -12,6 +12,12 @@ externalValues:
 global:
   clusterSize:    # injected via scripts/bootstrap.sh
   domain:         # injected via scripts/bootstrap.sh
+  aiGateway:
+    # Body-authz request-body ceiling, shared by envoy-gateway-config (gateway-scoped policy) and
+    # ai-gateway-discovery (per-model catch-all policies). The catch-all policies are rule-scoped
+    # and override the gateway one per route, so both must carry the same value. Rendered through
+    # int64 below: a bare number here is a float64 and would otherwise emit 4.194304e+06.
+    bodyAuthMaxRequestBytes: 4194304
 localHelmValues:
   enabled: false
 ociRegistry:
@@ -31,6 +37,9 @@ apps:
         value: "ai.{{ .Values.global.domain }}"
       - name: controller.gateway.name
         value: ai-gateway
+      # Same ceiling envoy-gateway-config renders into the gateway-scoped policy.
+      - name: controller.bodyAuthMaxRequestBytes
+        value: "{{ .Values.global.aiGateway.bodyAuthMaxRequestBytes | int64 }}"
   aim-engine:
     repoURL: "{{ .Values.ociRegistry.dockerHub }}"
     repoVersion: "0.2.5"
@@ -658,6 +667,8 @@ apps:
       # index (not dot access) because the app key contains dashes.
       - name: aiGateway.discoveryNamespace
         value: '{{ index .Values.apps "ai-gateway-discovery" "namespace" }}'
+      - name: aiGateway.bodyAuthMaxRequestBytes
+        value: "{{ .Values.global.aiGateway.bodyAuthMaxRequestBytes | int64 }}"
     namespace: envoy-gateway-system
     path: envoy-gateway-config
     syncWave: -15

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.aiGateway.enabled }}
+{{- $bodyAuthMax := .Values.aiGateway.bodyAuthMaxRequestBytes | int64 }}
+{{- if le $bodyAuthMax 0 }}{{ fail "aiGateway.bodyAuthMaxRequestBytes must be a positive integer; a float or scientific-notation value casts to 0 here and would publish maxRequestBytes: 0" }}{{ end }}
 # Gateway-scoped default-deny backstop for the `ai-gateway` Gateway (EAI-7304 cutover).
 #
 # Only model routes ride ai-gateway, so a blanket deny is safe here (unlike the shared
@@ -39,7 +41,7 @@ spec:
       # Ceiling on the header-less (model-in-body) path: a body over this returns HTTP 413 and
       # skips auth (overrides failOpen). Sized via values so large-context/image inference turns
       # are not rejected — see aiGateway.bodyAuthMaxRequestBytes.
-      maxRequestBytes: {{ .Values.aiGateway.bodyAuthMaxRequestBytes | int64 }}
+      maxRequestBytes: {{ $bodyAuthMax }}
     headersToExtAuth:
       - authorization
     http:

--- a/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
+++ b/sources/envoy-gateway-config/templates/security-policy-ai-gateway-default-deny.yaml
@@ -36,7 +36,10 @@ spec:
   extAuth:
     failOpen: false
     bodyToExtAuth:
-      maxRequestBytes: 65536
+      # Ceiling on the header-less (model-in-body) path: a body over this returns HTTP 413 and
+      # skips auth (overrides failOpen). Sized via values so large-context/image inference turns
+      # are not rejected — see aiGateway.bodyAuthMaxRequestBytes.
+      maxRequestBytes: {{ .Values.aiGateway.bodyAuthMaxRequestBytes | int64 }}
     headersToExtAuth:
       - authorization
     http:

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -38,3 +38,12 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
+  # Max request-body size (bytes) the body-aware extAuth filter buffers before calling
+  # ai-gateway-discovery. Envoy returns HTTP 413 (skipping auth, overriding failOpen) once a
+  # body exceeds this — so it is a hard ceiling on request size for the header-less (model-in-
+  # body) path that standard OpenAI/Anthropic clients use. The upstream default of 64KiB rejects
+  # ordinary large-context inference turns (a 200k-token coding request is ~1MB; image-bearing
+  # turns are larger). Set to 32MiB to match clients' own request ceiling; the ai-gateway
+  # ClientTrafficPolicy connection bufferLimit (50Mi) sits above it. Raising this increases the
+  # memory the extAuth path may hold per in-flight header-less request. (EAI-8489.)
+  bodyAuthMaxRequestBytes: 33554432

--- a/sources/envoy-gateway-config/values.yaml
+++ b/sources/envoy-gateway-config/values.yaml
@@ -38,12 +38,13 @@ aiGateway:
   # Stable ClusterIP `ai-gateway` (CoreDNS target / passthrough backend).
   dnsService:
     enabled: true
-  # Max request-body size (bytes) the body-aware extAuth filter buffers before calling
-  # ai-gateway-discovery. Envoy returns HTTP 413 (skipping auth, overriding failOpen) once a
-  # body exceeds this — so it is a hard ceiling on request size for the header-less (model-in-
-  # body) path that standard OpenAI/Anthropic clients use. The upstream default of 64KiB rejects
-  # ordinary large-context inference turns (a 200k-token coding request is ~1MB; image-bearing
-  # turns are larger). Set to 32MiB to match clients' own request ceiling; the ai-gateway
-  # ClientTrafficPolicy connection bufferLimit (50Mi) sits above it. Raising this increases the
-  # memory the extAuth path may hold per in-flight header-less request. (EAI-8489.)
-  bodyAuthMaxRequestBytes: 33554432
+  # Max request-body bytes the body-aware extAuth filter buffers before calling
+  # ai-gateway-discovery. Over this Envoy returns 413 and skips auth (overriding failOpen), so it
+  # is a hard request-size ceiling on the header-less (model-in-body) path standard
+  # OpenAI/Anthropic clients use. The upstream 64KiB default rejects ordinary large-context turns
+  # (~200k tokens is ~1MB). 4MiB covers those and stays within what the authz pod receiving the
+  # body can hold (its limits.memory is 256Mi).
+  # Keep in step with controller.bodyAuthMaxRequestBytes on ai-gateway-discovery: its per-model
+  # catch-all policies are rule-scoped and override this one per route, so the lower value wins.
+  # root/values.yaml drives both from global.aiGateway.bodyAuthMaxRequestBytes. (EAI-8489.)
+  bodyAuthMaxRequestBytes: 4194304


### PR DESCRIPTION
Backport of #832 (plus the follow-up commit on that branch) to `release/v2.4.x`. Cherry-picked with `-x`, both commits preserved.

- Parameterizes `bodyToExtAuth.maxRequestBytes` on the `ai-gateway-default-deny` SecurityPolicy as `aiGateway.bodyAuthMaxRequestBytes`, default 4MiB. The upstream 64KiB default returns HTTP 413 and skips authorization entirely (ahead of `failOpen`), so every large request on the header-less path was rejected before reaching a model.
- Drives both charts from `global.aiGateway.bodyAuthMaxRequestBytes` in `root/values.yaml`, so the gateway-scoped policy and the per-model catch-all policies stamped by `ai-gateway-discovery` cannot drift. The catch-all policies are rule-scoped and override the gateway-scoped one per route, so a mismatch is silently decided by whichever is lower.
- Renders through `int64` and fails the template on a non-positive value. A bare number in a values file is a float64, so an unguarded render emits `4.194304e+06`, which `int64` casts to `0` and would publish `maxRequestBytes: 0`.

Needs the matching `ai-gateway-discovery` change, silogen/core#4520, to be effective on any cluster with models deployed.

https://jira.amd.com/browse/EAI-8489

## How to test

Send a header-less inference request larger than 64KiB (model in the JSON body, no `x-ai-eg-model` header) with a valid API key. It returned 413 before and should now be served. Verified on app-dev against `MiniMaxAI/MiniMax-M2.5`: 40KB and 200KB return 200, 5MB returns 413 at the new ceiling, and no key returns 401.
