### PR TITLE
fix: aim-artifact-downloader version

### DIFF
--- a/root/values.yaml
+++ b/root/values.yaml
@@ -51,7 +51,7 @@ apps:
       - name: manager.image.repository
         value: silogenai/aim-engine
       - name: manager.artifactDownloaderImage
-        value: docker.io/silogenai/aim-artifact-downloader:0.2.6-rc1
+        value: docker.io/silogenai/aim-artifact-downloader:v0.2.6-rc1
       - name: clusterRuntimeConfig.enable
         value: 'false'
   aim-engine-crds:


### PR DESCRIPTION
 add missing 'v' to aim-engine.helmParameters for aim-artifact-downloader version