### PR TITLE
docs: add AIM catalog lifecycle and model management guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Comprehensive documentation is available in the `/docs` folder:
 | **Getting Started** | [On-Premises Installation Guide](https://enterprise-ai.docs.amd.com/en/latest/platform-infrastructure/on-premises-installation.html) |
 | **Configuration** | [Cluster Size Configuration](docs/cluster_size_configuration.md) · [Configuration Reference](docs/configuration-reference.md) |
 | **Architecture** | [Values Inheritance Pattern](docs/values_inheritance_pattern.md) |
+| **AIM Catalog** | [AIM catalog lifecycle](docs/aim_catalog_lifecycle.md) · [AIM model management](docs/aim_model_management.md) |
 | **Policy System** | [Kyverno Modular Design](docs/kyverno_modular_design.md) |
 | **Storage Policies** | [Kyverno Access Mode Policy](docs/kyverno_access_mode_policy.md) |
 | **Operations** | [Backup and Restore](docs/backup_and_restore.md) |

--- a/docs/aim_catalog_lifecycle.md
+++ b/docs/aim_catalog_lifecycle.md
@@ -1,0 +1,214 @@
+# AIM catalog lifecycle
+
+Reference for how AIM model catalog sources are packaged, extended, and retired on
+Enterprise AI reference stack clusters. This guide is for **cluster operators** who
+need to understand catalog behaviour and manage models over the life of a cluster.
+
+It is **not tied to the Cluster Forge release cadence**. Use it whenever you
+need to add, replace, or remove catalog entries: private builds, early access
+tags, bespoke models, or housekeeping after a platform upgrade.
+
+For step-by-step procedures (Gitea manifests, Argo CD sync, verification), see
+[AIM model management](aim_model_management.md).
+
+## Overview
+
+The catalog has two complementary layers:
+
+| Layer | Mechanism | Typical use |
+|-------|-----------|-------------|
+| **Packaged baseline** | `aim-cluster-model-source` Helm chart (Argo CD) | Default AMD catalog for the cluster hardware family; refreshed when you upgrade Cluster Forge |
+| **Cluster-managed additions** | Gitea `cluster-values` + `aim-cluster-model-source-additional` | Any extra model or base images you choose to expose — RCs, private builds, site-specific tags, or images not yet in the packaged chart |
+
+Cluster-managed additions do not replace the packaged baseline that ships with the
+cluster; the baseline keeps arriving and updating through Cluster Forge releases.
+Additions are an **operator-controlled extension** on top of it, available at any
+time.
+
+## Packaged baseline catalog
+
+Cluster Forge installs the in-tree Helm chart `sources/aim-cluster-model-source`.
+`AIMClusterModelSource` resources are selected by `hardwareFamilies`, which
+cluster-bloom sets from `AIM_HARDWARE_FAMILY`.
+
+| `hardwareFamilies` | Template | Result |
+|--------------------|----------|--------|
+| Non-empty list (`instinct`, `epyc`, `cpu`, `radeon`) | `templates/profiles.yaml` | Only listed families. The Instinct profile includes generic `amd-aim-release-*` sources (0.8.5–0.11.0) plus Instinct 0.11.1+. `cpu` is a placeholder and renders no sources. |
+| Empty list (`[]`, chart default) | `templates/unfiltered.yaml` | Instinct **0.11.1, 0.12.0, 0.13.0** plus mixed base images (`aim-base`, `aim-epyc-base`, `aim-radeon-base`). |
+
+`AIM_HARDWARE_FAMILY` has no default. cluster-bloom injects `hardwareFamilies`
+only when the install sets it, so an install that leaves it unset takes the
+**unfiltered** path. Set `AIM_HARDWARE_FAMILY` in `bloom.yaml` to get a
+family-filtered catalog:
+
+```yaml
+AIM_HARDWARE_FAMILY: "instinct"
+```
+
+Clearing `hardwareFamilies` to `[]` in Gitea on an existing cluster switches it
+back to **unfiltered**; it does not fail chart rendering. See the
+[aim-cluster-model-source README](../sources/aim-cluster-model-source/README.md).
+
+### Model release sources vs base catalog sources
+
+| Kind | Purpose | Example source name | Example images it lists |
+|------|---------|---------------------|-------------------------|
+| **Model release source** | Version-pinned model-specific images for a hardware family | `amd-aim-instinct-0.12.0` | `amdenterpriseai/aim-google-gemma-3-1b-it:0.12.0`, `amdenterpriseai/aim-zai-org-glm-4-7:0.12.0` |
+| **Model release source** | Same, EPYC family | `amd-aim-epyc-0.13.0` | `amdenterpriseai/aim-epyc-qwen-qwen3-8b:0.13.0` |
+| **Base catalog source** | Generic base images for AI Workbench custom model onboarding (runtime AIM ID) | `aim-base-models` | `amdenterpriseai/aim-base:0.13.1`, `amdenterpriseai/aim-epyc-base:0.13`, `amdenterpriseai/aim-radeon-base:0.12` |
+
+Source names such as `amd-aim-instinct-0.12.0` are `AIMClusterModelSource`
+resource names, not image references. The images each source lists are fully
+qualified `repository/name:tag` values, as in the last column.
+
+Model release sources list **model-specific** images. Base catalog sources list
+**base** images only.
+
+Bases are split **by hardware family** in the packaged chart so AI Workbench
+does not show large numbers of not-deployable entries on clusters without
+matching hardware.
+
+Each family profile installs only its own base images: Instinct → `aim-base`,
+EPYC → `aim-epyc-base`, Radeon → `aim-radeon-base`. The `unfiltered` template is
+the one exception — it installs all three, because it has no family to filter
+on.
+
+### Source of truth
+
+Canonical model source and base-image lists live in an AMD-internal repository
+that operators cannot access. There is no automated feed from it into a
+cluster. Those lists are copied into
+`sources/aim-cluster-model-source/templates/` by hand when a Cluster Forge
+release is prepared. The chart templates in a given release are therefore a
+**point-in-time snapshot**, not a live mirror: an AIM version published after
+that release does not appear in the packaged baseline until a later Cluster
+Forge release picks it up.
+
+For a cluster, the operator-visible source of truth is
+`sources/aim-cluster-model-source/` in the Cluster Forge release you installed.
+To read the catalog it will install before you deploy, render the chart:
+
+```bash
+helm template aim-cluster-model-source sources/aim-cluster-model-source \
+  --set-json 'hardwareFamilies=["instinct"]' | grep -E '^  name:'
+```
+
+If you need an AIM version sooner than the next Cluster Forge release, use
+[cluster-managed additions](#cluster-managed-catalog-additions) — that is the
+only path that does not wait on packaging.
+
+Environment-specific CI snapshots are not packaged in Cluster Forge.
+
+## Version policy
+
+| Scenario | Policy |
+|----------|--------|
+| **New installation, `AIM_HARDWARE_FAMILY` set** | Injects a non-empty list → **profiles** branch. The Instinct profile installs generic `amd-aim-release-*` 0.8.5–0.11.0 alongside `amd-aim-instinct-*` 0.11.1, 0.12.0, 0.13.0, so such an install starts with all of them. |
+| **New installation, `AIM_HARDWARE_FAMILY` unset** | Nothing is injected → chart default `[]` → **unfiltered** catalog. |
+| **Empty `hardwareFamilies` in Gitea** | **unfiltered** catalog: Instinct 0.11.1+ only (no generic 0.8.x–0.11.0 sources). |
+| **Platform upgrade** | New AIM versions are **added**. Older versions are **not** removed automatically. |
+| **Catalog cleanup** | Manual. The cluster operator removes deprecated sources; nothing expires on its own. |
+
+There is no automated deprecation schedule. An older AIM version stays in the
+catalog until its `AIMClusterModelSource` is deleted. Narrowing a filter is not
+enough — see [Filter removal vs source removal](#filter-removal-vs-source-removal).
+
+This applies to cluster-managed additions. Packaged baseline sources are owned
+by the `aim-cluster-model-source` chart and are restored by the next Argo CD
+sync if deleted in the cluster. The chart's only selector is `hardwareFamilies`,
+which switches whole family profiles; it cannot drop an individual packaged
+version. Packaged source names (`amd-aim-instinct-0.12.0`,
+`amd-aim-epyc-0.13.0`, and so on) are therefore a **stable API**: a Cluster
+Forge release adds tracks; it does not delete source names from the chart.
+
+## Cluster-managed catalog additions
+
+Cluster operators add or remove sources through Gitea and Argo CD; see
+[AIM model management](aim_model_management.md).
+
+`aim-cluster-model-source-additional` is not shipped in Cluster Forge. The
+operator defines it once in Gitea `cluster-values` (`enabledApps` plus an `apps`
+entry) before this path is available — see
+[One-time setup](aim_model_management.md#one-time-setup).
+
+Typical lifecycle, once it is enabled:
+
+1. Gitea stores `AIMClusterModelSource` manifests in `cluster-values`.
+2. The `cluster-forge` parent application creates `aim-cluster-model-source-additional`.
+3. AIM Engine discovers images and creates `AIMClusterModel` resources.
+4. AI Workbench refreshes its catalog periodically.
+
+Use this path whenever the packaged baseline does not include the image you
+need — regardless of whether a Cluster Forge upgrade is planned.
+
+### Hardware family and catalog UX
+
+The packaged baseline is family-filtered when `hardwareFamilies` is non-empty.
+Cluster-managed additions can list any image, but entries for the wrong
+accelerator appear as **not deployable** in AI Workbench. Prefer family-matched
+images and the `{family}-*.yaml` filename convention described in
+[Add a model](aim_model_management.md#add-a-model).
+
+## Filter removal vs source removal
+
+AIM Engine discovery is append-only. Two edits that look similar in YAML have
+opposite runtime effects:
+
+| Action | What happens | Running deployments |
+|--------|--------------|---------------------|
+| Drop an image from `spec.filters` (or `spec.images`) on an existing source | Already-discovered `AIMClusterModel` resources **stay**. The catalog can keep showing the old image. | Unaffected |
+| Delete the `AIMClusterModelSource` (Gitea manifest + Argo CD prune, or drop the source **name** from the packaged chart) | The CR is deleted. Kubernetes garbage-collects every `AIMClusterModel` it owned. | **Can break** workloads that still use those models |
+
+A “hollow shell” — keep the source CR but empty the filter list — **does not
+work**. The `AIMClusterModelSource` CRD requires at least one entry in
+`spec.filters` or `spec.images` (`MinItems=1`), so empty filters fail
+validation.
+
+**To retire a model you actually want gone**, delete the source (and sync with
+prune), as in
+[Replace or remove a source](aim_model_management.md#replace-or-remove-a-source).
+You do not delete `AIMClusterModel` resources separately.
+
+**To keep running deployments** while stopping new discoveries of an image,
+leave the source name in place and stop listing that image. Expect catalog
+clutter until a later source deletion.
+
+**Do not delete packaged source names** from `sources/aim-cluster-model-source`
+between Cluster Forge releases. Retire a track by adding a new source; leaving
+the old name is what keeps existing clusters from having their models
+garbage-collected on the next chart sync.
+
+## Lifecycle constraints
+
+- **Discovery is additive** — adding a filter can create another
+  `AIMClusterModel`.
+- **Removing a filter does not remove discovered models** — see above.
+- **Removing the additional Argo CD Application does not delete its resources**
+  — child apps lack a cascading-resources finalizer.
+- **Deleting an `AIMClusterModelSource` garbage-collects its owned models.**
+
+Remove or replace source manifests while the additional application still
+exists. Disable the application only after sources are pruned.
+
+When upgrading Cluster Forge, review the incoming packaged catalog and remove
+cluster-managed manifests that duplicate newly packaged models or bases before
+syncing — see
+[Before a platform upgrade](aim_model_management.md#before-a-platform-upgrade).
+
+## Responsibilities
+
+| Responsibility | Owner |
+|----------------|-------|
+| Packaged baseline catalog (what a new cluster gets) | The Cluster Forge release you installed |
+| Choosing `AIM_HARDWARE_FAMILY` at install | Whoever runs cluster-bloom |
+| Cluster-managed catalog additions and removals | Cluster operator |
+| Removing deprecated catalog entries | Cluster operator |
+
+## Related documentation
+
+- [AIM model management](aim_model_management.md) — procedural guide
+  for cluster operators
+- [aim-cluster-model-source README](../sources/aim-cluster-model-source/README.md)
+  — Helm chart reference
+- [Values inheritance pattern](values_inheritance_pattern.md) — how
+  `hardwareFamilies` reaches the chart

--- a/docs/aim_model_management.md
+++ b/docs/aim_model_management.md
@@ -1,0 +1,198 @@
+# AIM model management
+
+Step-by-step guide for cluster operators who need to add, replace, or remove AIM
+container images in the AI Workbench model catalog.
+
+For packaged baseline behaviour, version policy, and lifecycle rules, see
+[AIM catalog lifecycle](aim_catalog_lifecycle.md).
+
+Validated with Cluster Forge >= v2.2.2 and AIM Engine 0.2.5.
+
+## Before you start
+
+You need:
+
+- cluster administrator access;
+- Gitea and Argo CD web access;
+- `kubectl` access for validation;
+- an image AIM Engine can inspect (valid AIM metadata); and
+- registry reachability from AIM Engine (namespace `aim-system`).
+
+Use images that match the cluster's hardware family. Listing images for other
+accelerators creates catalog entries that AI Workbench marks as not deployable.
+Active families:
+
+```bash
+kubectl get application -n argocd aim-cluster-model-source -o go-template='{{ index (fromYaml .spec.source.helm.values) "hardwareFamilies" }}{{ println }}'
+```
+
+...also in Gitea **cluster-values** → `values.yaml` → `apps.aim-cluster-model-source.valuesObject.hardwareFamilies`.
+An empty list there selects `templates/unfiltered.yaml` (Instinct 0.11.1+ plus mixed
+bases).
+
+For private registries, set `spec.imagePullSecrets` on the source to a secret in
+`aim-system`. Do not commit credentials to Gitea.
+
+## One-time setup
+
+Skip this section if `aim-cluster-model-source-additional` is already in
+`enabledApps`.
+
+Edit `cluster-org/cluster-values` → `values.yaml` in Gitea:
+
+```yaml
+enabledApps:
+  # Existing applications remain here.
+  - aim-cluster-model-source
+  - aim-cluster-model-source-additional
+
+apps:
+  # Existing application definitions remain here.
+
+  aim-cluster-model-source-additional:
+    repoURL: http://gitea-http.cf-gitea.svc:3000/cluster-org/cluster-values.git
+    repoVersion: main
+    path: "."
+    namespace: kaiwo-system
+    syncWave: -20
+    directory:
+      include: "{cpu-*.yaml,epyc-*.yaml,instinct-*.yaml,radeon-*.yaml}"
+```
+
+Commit to `main`, then refresh or sync the `cluster-forge` parent application in
+Argo CD.
+
+## Add a model
+
+### 1. Create the manifest in Gitea
+
+1. Open `cluster-org/cluster-values`.
+2. **New File** at the repository root.
+3. Name the file `{family}-{model}-{version}.yaml`, for example
+   `epyc-qwen3-8b-0-13-0.yaml`.
+4. Paste a manifest like:
+
+```yaml
+apiVersion: aim.eai.amd.com/v1alpha1
+kind: AIMClusterModelSource
+metadata:
+  name: epyc-qwen3-8b-0-13-0
+spec:
+  registry: docker.io
+  filters:
+    - image: amdenterpriseai/aim-epyc-qwen-qwen3-8b:0.13.0
+  maxModels: 10
+  syncInterval: 15m
+```
+
+5. Commit to `main`.
+
+Use immutable names with hardware family, model, and version. Avoid names like
+`latest`.
+
+Filename prefixes:
+
+```text
+cpu-<model>-<version>.yaml
+epyc-<model>-<version>.yaml
+instinct-<model>-<version>.yaml
+radeon-<model>-<version>.yaml
+```
+
+### 2. Sync and verify
+
+Refresh `aim-cluster-model-source-additional` in Argo CD if it does not sync
+automatically.
+
+```bash
+kubectl get application -n argocd aim-cluster-model-source-additional
+kubectl get aimclustermodelsource epyc-qwen3-8b-0-13-0 --watch
+kubectl get aimclustermodels \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.spec.image,STATUS:.status.status
+```
+
+Refresh the AI Workbench catalog (or wait at least 30 seconds).
+
+## Add a base image
+
+Same workflow as a model-specific image. Example for an Instinct base tag not
+yet in the packaged catalog:
+
+```yaml
+apiVersion: aim.eai.amd.com/v1alpha1
+kind: AIMClusterModelSource
+metadata:
+  name: instinct-base-0-13-1
+spec:
+  registry: docker.io
+  filters:
+    - image: amdenterpriseai/aim-base:0.13.1
+  maxModels: 10
+  syncInterval: 1h
+```
+
+Save as `instinct-base-0-13-1.yaml`. Base additions should stay
+family-specific (`aim-base` on Instinct, `aim-epyc-base` on EPYC, and so on).
+
+## Replace or remove a source
+
+**Do not** remove entries by narrowing filters on an existing source — discovery
+is append-only. The image stays in the catalog as an `AIMClusterModel` until the
+source itself is deleted. Emptying `spec.filters` is not a workaround: the CRD
+requires at least one filter or image.
+
+Deleting the source **is** how models leave the catalog, and it is a breaking
+change for anything still using them: Argo CD prune removes the
+`AIMClusterModelSource`, then Kubernetes garbage-collects its owned
+`AIMClusterModel` resources. Confirm no running deployments depend on those
+images before you prune. See
+[Filter removal vs source removal](aim_catalog_lifecycle.md#filter-removal-vs-source-removal).
+
+**Replace:**
+
+1. Add the new manifest; delete the old one in the same commit.
+2. Sync `aim-cluster-model-source-additional` with **prune** enabled.
+3. Confirm the old `AIMClusterModelSource` and its models are gone.
+
+**Remove only:**
+
+1. Delete the manifest.
+2. Sync with prune enabled.
+3. Verify cleanup before disabling the additional application.
+
+```bash
+kubectl get aimclustermodelsource <source-name>
+kubectl get aimclustermodels
+```
+
+## Disable the additional application
+
+Only after all additional sources are removed and pruned:
+
+1. Delete every `{family}-*.yaml` catalog manifest from Gitea.
+2. Sync `aim-cluster-model-source-additional` with prune enabled.
+3. Confirm no additional `AIMClusterModelSource` resources remain.
+4. Remove `aim-cluster-model-source-additional` from `enabledApps`.
+5. Sync the `cluster-forge` parent with prune enabled.
+
+Removing the application first leaves orphaned sources in the cluster.
+
+## Before a platform upgrade
+
+1. Review the incoming packaged catalog.
+2. Delete additional manifests that duplicate packaged models or bases.
+3. Sync with prune enabled.
+4. Upgrade only when the additional catalog has no unintended duplicates.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --------- | -------- |
+| Additional app missing | `enabledApps` entry, `apps` definition, parent `cluster-forge` synced |
+| Model remains after app removed | Source was not pruned first — `kubectl delete aimclustermodelsource <name>` |
+| Filter removed but model remains | Append-only discovery — delete and replace the source |
+| Registry/discovery error | Image tag, reachability, pull secret, AIM Engine logs in `aim-system` |
+| Model in K8s but not AI Workbench | `AIMClusterModel` status; refresh catalog; wait 30s |
+| Many not-deployable entries | Additional images for wrong hardware family — fix or remove manifests |
+
+See [AIM catalog lifecycle](aim_catalog_lifecycle.md) for full lifecycle rules.


### PR DESCRIPTION
## Summary
- Add the operator AIM catalog guides onto `release/v2.4.x` under the scoped filenames (`aim_catalog_lifecycle.md`, `aim_model_management.md`). These files exist on `main` but were never on this release branch.
- Link both from the README Documentation table.
- Guides match companion PR #839 (`docs_minor_aim_doc_updates` → `main`): TOCs, pre-upgrade `helm`/`kubectl` one-liners, and the `AIMService` in-use check.

GitHub cannot use one head branch for both targets: `docs_minor_aim_doc_updates` is based on `main` and would pull ~33 unrelated commits into `release/v2.4.x`. This PR keeps head `docs_minor_aim_doc_updates_v24x` with the same guide files.

## Test plan
- [ ] README AIM Catalog row links resolve on this branch
- [ ] `docs/aim_catalog_lifecycle.md` and `docs/aim_model_management.md` match #839

Made with [Cursor](https://cursor.com)